### PR TITLE
add feature gate AppPusher

### DIFF
--- a/manifests/crds/clusters.clusternet.io_managedclusters.yaml
+++ b/manifests/crds/clusters.clusternet.io_managedclusters.yaml
@@ -70,6 +70,9 @@ spec:
               apiserverURL:
                 description: APIServerURL indicates the advertising url/address of managed Kubernetes cluster
                 type: string
+              appPusher:
+                description: AppPusher indicates whether to allow parent cluster deploying applications in Push. Mainly for security concerns.
+                type: boolean
               healthz:
                 description: Healthz indicates the healthz status of the cluster which is deprecated since Kubernetes v1.16. Please use Livez and Readyz instead. Leave it here only for compatibility.
                 type: boolean

--- a/pkg/apis/clusters/v1beta1/types.go
+++ b/pkg/apis/clusters/v1beta1/types.go
@@ -188,6 +188,11 @@ type ManagedClusterStatus struct {
 	// Readyz indicates the readyz status of the cluster
 	// +optional
 	Readyz bool `json:"readyz,omitempty"`
+
+	// AppPusher indicates whether to allow parent cluster deploying applications in Push.
+	// Mainly for security concerns.
+	// +optional
+	AppPusher bool `json:"appPusher,omitempty"`
 }
 
 // +genclient

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -28,6 +28,13 @@ const (
 	// Setup/Serve a WebSocket connection.
 	SocketConnection featuregate.Feature = "SocketConnection"
 
+	// alpha: v0.2.0
+	//
+	// Allow to deploy applications from parent cluster.
+	// Mainly for security concerns of every child cluster.
+	// If a child cluster has disabled AppPusher, the parent cluster won't deploy applications with Push mode.
+	AppPusher featuregate.Feature = "AppPusher"
+
 	// TODO
 )
 
@@ -40,4 +47,5 @@ func init() {
 // available throughout Clusternet binaries.
 var defaultClusternetFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SocketConnection: {Default: false, PreRelease: featuregate.Alpha, LockToDefault: false},
+	AppPusher:        {Default: false, PreRelease: featuregate.Alpha, LockToDefault: false},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

#### What this PR does / why we need it:

With regard to security of child clusters, deploying applications directly from parent cluster should be limited. A configurable way should be provided to disallow that.

If a child cluster has disabled `AppPusher` by feature gate, the parent cluster won't deploy applications, even if the sync mode of child cluster is set to `Push` or `Dual`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

This PR only focuses on adding feature gate `AppPusher`. Following PRs will address the rest implementations.