### PR TITLE
add cluster sync mode Pull, Push and Dual

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    clusters.clusternet.io/rbac-autoupdate: "true"
+    clusternet.io/autoupdate: "true"
   creationTimestamp: "2021-05-24T08:25:07Z"
   labels:
     clusters.clusternet.io/bootstrapping: rbac-defaults
@@ -232,7 +232,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   annotations:
-    clusters.clusternet.io/rbac-autoupdate: "true"
+    clusternet.io/autoupdate: "true"
   creationTimestamp: "2021-05-24T08:25:07Z"
   labels:
     clusters.clusternet.io/bootstrapping: rbac-defaults

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ kubectl apply -f deploy/agent
 ```bash
 # clsrr is an alias for ClusterRegistrationRequest
 $ kubectl get clsrr
-NAME                                              CLUSTER-ID                             STATUS     AGE
+NAME                                              CLUSTER ID                             STATUS     AGE
 clusternet-dc91021d-2361-4f6d-a404-7c33b9e01118   dc91021d-2361-4f6d-a404-7c33b9e01118   Approved   3d6h
 $ kubectl get clsrr clusternet-dc91021d-2361-4f6d-a404-7c33b9e01118 -o yaml
 apiVersion: clusters.clusternet.io/v1beta1
@@ -254,9 +254,11 @@ rules:
 
 ```bash
 # mcls is an alias for ManagedCluster
-$ kubectl get mcls -A
-NAMESPACE          NAME                       CLUSTER-ID                             CLUSTER-TYPE                 KUBERNETES   READYZ   AGE
-clusternet-dhxfs   clusternet-cluster-dzqkw   dc91021d-2361-4f6d-a404-7c33b9e01118   EdgeClusterSelfProvisioned   v1.19.10     true     2d20h
+# kubectl get mcls -A
+# or append "-o wide" to display extra columns
+$ kubectl get mcls -A -o wide
+NAMESPACE          NAME                       CLUSTER ID                             CLUSTER TYPE                 SYNC MODE   KUBERNETES   READYZ   AGE
+clusternet-dhxfs   clusternet-cluster-dzqkw   dc91021d-2361-4f6d-a404-7c33b9e01118   EdgeClusterSelfProvisioned   Pull        v1.19.10     true     7d23h
 $ kubectl get mcls -n clusternet-dhxfs   clusternet-cluster-dzqkw -o yaml
 apiVersion: clusters.clusternet.io/v1beta1
 kind: ManagedCluster
@@ -274,6 +276,7 @@ metadata:
 spec:
   clusterId: dc91021d-2361-4f6d-a404-7c33b9e01118
   clusterType: EdgeClusterSelfProvisioned
+  syncMode: Pull
 status:
   healthz: true
   k8sVersion: v1.19.10

--- a/deploy/agent/clusternet_agent_deployment.yaml
+++ b/deploy/agent/clusternet_agent_deployment.yaml
@@ -11,6 +11,13 @@ metadata:
   namespace: clusternet-system
 
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clusternet-app-deployer
+  namespace: clusternet-system
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/agent/clusternet_agent_deployment.yaml
+++ b/deploy/agent/clusternet_agent_deployment.yaml
@@ -51,5 +51,6 @@ spec:
             - /usr/local/bin/clusternet-agent
             - --cluster-reg-token=$(REG_TOKEN)
             - --cluster-reg-parent-url=$(PARENT_URL)
-            - --feature-gates=SocketConnection=true
+            - --cluster-sync-mode=Dual
+            - --feature-gates=SocketConnection=true,AppPusher=true
             - -v=4

--- a/deploy/agent/clusternet_agent_rbac.yaml
+++ b/deploy/agent/clusternet_agent_rbac.yaml
@@ -22,3 +22,27 @@ subjects:
   - kind: ServiceAccount
     name: clusternet-agent
     namespace: clusternet-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusternet:app:deployer
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusternet:app:deployer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusternet:app:deployer
+subjects:
+  - kind: ServiceAccount
+    name: clusternet-app-deployer
+    namespace: clusternet-system

--- a/manifests/crds/clusters.clusternet.io_clusterregistrationrequests.yaml
+++ b/manifests/crds/clusters.clusternet.io_clusterregistrationrequests.yaml
@@ -23,14 +23,14 @@ spec:
   - additionalPrinterColumns:
     - description: The unique id for the cluster
       jsonPath: .spec.clusterId
-      name: Cluster-ID
+      name: CLUSTER ID
       type: string
     - description: The status of current cluster registration request
       jsonPath: .status.result
-      name: Status
+      name: STATUS
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: Age
+      name: AGE
       type: date
     name: v1beta1
     schema:
@@ -60,6 +60,14 @@ spec:
               clusterType:
                 description: ClusterType denotes the type of the child cluster.
                 type: string
+              syncMode:
+                default: Pull
+                description: SyncMode decides how to sync resources from parent cluster to child cluster.
+                enum:
+                - Push
+                - Pull
+                - Dual
+                type: string
             required:
             - clusterId
             type: object
@@ -71,7 +79,7 @@ spec:
                 format: byte
                 type: string
               dedicatedNamespace:
-                description: DedicatedNamespace is a dedicated namespace for the edge cluster, which is created in the parent cluster.
+                description: DedicatedNamespace is a dedicated namespace for the child cluster, which is created in the parent cluster.
                 type: string
               errorMessage:
                 description: ErrorMessage tells the reason why the request is not approved successfully.

--- a/manifests/crds/clusters.clusternet.io_managedclusters.yaml
+++ b/manifests/crds/clusters.clusternet.io_managedclusters.yaml
@@ -23,20 +23,25 @@ spec:
   - additionalPrinterColumns:
     - description: The unique id for the cluster
       jsonPath: .spec.clusterId
-      name: Cluster-ID
+      name: CLUSTER ID
       type: string
     - description: The type of the cluster
       jsonPath: .spec.clusterType
-      name: Cluster-Type
+      name: CLUSTER TYPE
+      priority: 100
+      type: string
+    - description: The cluster sync mode
+      jsonPath: .spec.syncMode
+      name: SYNC MODE
       type: string
     - jsonPath: .status.k8sVersion
-      name: Kubernetes
+      name: KUBERNETES
       type: string
     - jsonPath: .status.readyz
-      name: Readyz
+      name: READYZ
       type: string
     - jsonPath: .metadata.creationTimestamp
-      name: Age
+      name: AGE
       type: date
     name: v1beta1
     schema:
@@ -61,8 +66,16 @@ spec:
               clusterType:
                 description: ClusterType denotes the type of the child cluster.
                 type: string
+              syncMode:
+                description: SyncMode decides how to sync resources from parent cluster to child cluster.
+                enum:
+                - Push
+                - Pull
+                - Dual
+                type: string
             required:
             - clusterId
+            - syncMode
             type: object
           status:
             description: ManagedClusterStatus defines the observed state of ManagedCluster
@@ -71,7 +84,7 @@ spec:
                 description: APIServerURL indicates the advertising url/address of managed Kubernetes cluster
                 type: string
               appPusher:
-                description: AppPusher indicates whether to allow parent cluster deploying applications in Push. Mainly for security concerns.
+                description: AppPusher indicates whether to allow parent cluster deploying applications in Push or Dual Mode. Mainly for security concerns.
                 type: boolean
               healthz:
                 description: Healthz indicates the healthz status of the cluster which is deprecated since Kubernetes v1.16. Please use Livez and Readyz instead. Leave it here only for compatibility.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -217,7 +217,9 @@ func (agent *Agent) bootstrapClusterRegistrationIfNeeded(ctx context.Context) er
 	// create ClusterRegistrationRequest
 	client := clusternetClientSet.NewForConfigOrDie(clientConfig)
 	crr, err := client.ClustersV1beta1().ClusterRegistrationRequests().Create(ctx,
-		newClusterRegistrationRequest(*agent.ClusterID, agent.Options.ClusterType, generateClusterName(agent.Options.ClusterName, agent.Options.ClusterNamePrefix)),
+		newClusterRegistrationRequest(*agent.ClusterID, agent.Options.ClusterType,
+			generateClusterName(agent.Options.ClusterName, agent.Options.ClusterNamePrefix),
+			agent.Options.ClusterSyncMode),
 		metav1.CreateOptions{})
 
 	if err != nil {
@@ -372,7 +374,7 @@ func newLeaderElectionConfigWithDefaultValue(identity string, clientset kubernet
 	}
 }
 
-func newClusterRegistrationRequest(clusterID types.UID, clusterType, clusterName string) *clusterapi.ClusterRegistrationRequest {
+func newClusterRegistrationRequest(clusterID types.UID, clusterType, clusterName, clusterSyncMode string) *clusterapi.ClusterRegistrationRequest {
 	return &clusterapi.ClusterRegistrationRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: generateClusterRegistrationRequestName(clusterID),
@@ -386,6 +388,7 @@ func newClusterRegistrationRequest(clusterID types.UID, clusterType, clusterName
 			ClusterID:   clusterID,
 			ClusterType: clusterapi.ClusterType(clusterType),
 			ClusterName: clusterName,
+			SyncMode:    clusterapi.ClusterSyncMode(clusterSyncMode),
 		},
 	}
 }

--- a/pkg/agent/constant.go
+++ b/pkg/agent/constant.go
@@ -53,7 +53,15 @@ const (
 	SelfClusterLeaseName      = "self-cluster"
 	ClusternetSystemNamespace = "clusternet-system"
 	ParentClusterSecretName   = "parent-cluster"
-	ParentURLKey              = "parent-url"
+	ClusterAPIServerURLKey    = "apiserver-advertise-url"
+	ChildClusterSecretName    = "child-cluster-deployer"
+
+	// ServiceAccountNameKey is the key of the required annotation for SecretTypeServiceAccountToken secrets
+	ServiceAccountNameKey = "service-account.name"
+	// ServiceAccountUIDKey is the key of the required annotation for SecretTypeServiceAccountToken secrets
+	ServiceAccountUIDKey = "service-account.uid"
+
+	ClusternetAppSA = "clusternet-app-deployer"
 
 	// RegistrationNamePrefix is a prefix name for cluster registration
 	RegistrationNamePrefix = "clusternet-cluster"

--- a/pkg/agent/constant.go
+++ b/pkg/agent/constant.go
@@ -38,6 +38,9 @@ const (
 	// ClusterRegistrationType flag specifies the cluster type
 	ClusterRegistrationType = "cluster-reg-type"
 
+	// ClusterSyncMode flag specifies the sync mode between parent cluster and child cluster
+	ClusterSyncMode = "cluster-sync-mode"
+
 	// ClusterStatusReportFrequency flag specifies the child cluster status updating frequency
 	ClusterStatusReportFrequency = "cluster-status-update-frequency"
 

--- a/pkg/agent/deployer.go
+++ b/pkg/agent/deployer.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
+	"github.com/clusternet/clusternet/pkg/features"
+	"github.com/clusternet/clusternet/pkg/known"
+)
+
+type Deployer struct {
+	SyncMode clusterapi.ClusterSyncMode
+	// clientset for child cluster
+	childKubeClientSet *kubernetes.Clientset
+	childAPIServerURL  string
+	// whether AppPusher feature gate is enabled
+	appPusherEnabled bool
+}
+
+func NewDeployer(syncMode, childAPIServerURL string, childKubeClientSet *kubernetes.Clientset) *Deployer {
+	return &Deployer{
+		SyncMode:           clusterapi.ClusterSyncMode(syncMode),
+		childAPIServerURL:  childAPIServerURL,
+		childKubeClientSet: childKubeClientSet,
+		appPusherEnabled:   utilfeature.DefaultFeatureGate.Enabled(features.AppPusher),
+	}
+}
+
+func (d *Deployer) Run(ctx context.Context, parentDedicatedKubeConfig *rest.Config, secret *corev1.Secret, clusterID *types.UID) {
+	klog.Infof("starting deployer ...")
+
+	// in case the dedicated kubeconfig get changed when leader election gets lost,
+	// initialize the client when Run() is called
+	parentClientSet := kubernetes.NewForConfigOrDie(parentDedicatedKubeConfig)
+
+	dedicatedNamespace := string(secret.Data[corev1.ServiceAccountNamespaceKey])
+	// make sure deployer gets initialized before we go next
+	d.getInitialized(ctx, dedicatedNamespace, parentClientSet, clusterID)
+
+	// TODO: add puller ops
+}
+
+func (d *Deployer) getInitialized(ctx context.Context, dedicatedNamespace string, parentClientSet *kubernetes.Clientset, clusterID *types.UID) {
+	if d.appPusherEnabled && d.SyncMode != clusterapi.Pull {
+		klog.V(4).Infof("initializing deployer with sync mode %s", d.SyncMode)
+
+		secret := d.getDeployerCredentials(ctx)
+		createDeployerCredentialsToParentCluster(ctx, parentClientSet, string(*clusterID), dedicatedNamespace, d.childAPIServerURL, secret)
+	}
+}
+
+func (d *Deployer) getDeployerCredentials(ctx context.Context) *corev1.Secret {
+	var secret *corev1.Secret
+	localCtx, cancel := context.WithCancel(ctx)
+
+	klog.V(4).Infof("get ServiceAccount %s/%s", ClusternetSystemNamespace, ClusternetAppSA)
+	wait.JitterUntil(func() {
+		sa, err := d.childKubeClientSet.CoreV1().ServiceAccounts(ClusternetSystemNamespace).Get(localCtx, ClusternetAppSA, metav1.GetOptions{})
+		if err != nil {
+			klog.ErrorDepth(5, fmt.Errorf("failed to get ServiceAccount %s/%s: %v", ClusternetSystemNamespace, ClusternetAppSA, err))
+			return
+		}
+
+		if len(sa.Secrets) == 0 {
+			klog.ErrorDepth(5, fmt.Errorf("no secrets found in ServiceAccount %s/%s", ClusternetSystemNamespace, ClusternetAppSA))
+			return
+		}
+
+		secret, err = d.childKubeClientSet.CoreV1().Secrets(ClusternetSystemNamespace).Get(localCtx, sa.Secrets[0].Name, metav1.GetOptions{})
+		if err != nil {
+			klog.ErrorDepth(5, fmt.Errorf("failed to get Secret %s/%s: %v", ClusternetSystemNamespace, sa.Secrets[0].Name, err))
+			return
+		}
+
+		cancel()
+		return
+	}, DefaultRetryPeriod, 0.4, true, localCtx.Done())
+
+	klog.V(4).Info("successfully get credentials populated for deployer")
+	return secret
+}
+
+func createDeployerCredentialsToParentCluster(ctx context.Context, parentClientSet *kubernetes.Clientset,
+	clusterID, dedicatedNamespace, childAPIServerURL string, secretInChildCluster *corev1.Secret) {
+	// create child cluster credentials to parent cluster for app deployer
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ChildClusterSecretName,
+			Namespace: dedicatedNamespace,
+			Labels: map[string]string{
+				known.ClusterRegisteredByLabel: known.ClusternetAgentName,
+				known.ClusterIDLabel:           clusterID,
+			},
+			Annotations: map[string]string{
+				known.AutoUpdateAnnotationKey: "true",
+			},
+		},
+		Data: map[string][]byte{
+			corev1.ServiceAccountRootCAKey: secretInChildCluster.Data[corev1.ServiceAccountRootCAKey],
+			corev1.ServiceAccountTokenKey:  secretInChildCluster.Data[corev1.ServiceAccountTokenKey],
+			ServiceAccountNameKey:          []byte(secretInChildCluster.Annotations[corev1.ServiceAccountNameKey]),
+			ServiceAccountUIDKey:           []byte(secretInChildCluster.Annotations[corev1.ServiceAccountUIDKey]),
+			ClusterAPIServerURLKey:         []byte(childAPIServerURL),
+		},
+	}
+
+	localCtx, cancel := context.WithCancel(ctx)
+	wait.JitterUntil(func() {
+		_, err := parentClientSet.CoreV1().Secrets(dedicatedNamespace).Create(localCtx, secret, metav1.CreateOptions{})
+		if err == nil {
+			klog.V(5).Infof("successfully create deployer credentials %s in parent cluster", klog.KObj(secret))
+			cancel()
+			return
+		} else {
+			if apierrors.IsAlreadyExists(err) {
+				klog.V(5).Infof("found existed Secret %s in parent cluster, will try to update it", klog.KObj(secret))
+
+				// try to auto update existing object
+				sct, err := parentClientSet.CoreV1().Secrets(dedicatedNamespace).Get(localCtx, secret.Name, metav1.GetOptions{})
+				if err != nil {
+					klog.ErrorDepth(5, fmt.Sprintf("failed to get Secret %s in parent cluster: %v, will retry",
+						klog.KObj(secret), err))
+					return
+				}
+				if autoUpdate, ok := sct.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
+					_, err = parentClientSet.CoreV1().Secrets(dedicatedNamespace).Update(ctx, secret, metav1.UpdateOptions{})
+					if err == nil {
+						// success on the updating
+						cancel()
+						return
+					}
+					klog.ErrorDepth(5, fmt.Sprintf("failed to update Secret %s in parent cluster: %v, will retry",
+						klog.KObj(secret), err))
+					return
+				}
+			}
+			klog.ErrorDepth(5, fmt.Sprintf("failed to create Secret %s: %v, will retry", klog.KObj(secret), err))
+		}
+	}, DefaultRetryPeriod, 0.4, true, localCtx.Done())
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -32,7 +32,7 @@ const (
 	//
 	// Allow to deploy applications from parent cluster.
 	// Mainly for security concerns of every child cluster.
-	// If a child cluster has disabled AppPusher, the parent cluster won't deploy applications with Push mode.
+	// If a child cluster has disabled AppPusher, the parent cluster won't deploy applications with Push or Dual mode.
 	AppPusher featuregate.Feature = "AppPusher"
 
 	// TODO

--- a/pkg/hub/approver/approver.go
+++ b/pkg/hub/approver/approver.go
@@ -24,7 +24,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,6 +41,7 @@ import (
 	clusternetClientSet "github.com/clusternet/clusternet/pkg/generated/clientset/versioned"
 	clusterInformers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions/clusters/v1beta1"
 	"github.com/clusternet/clusternet/pkg/known"
+	"github.com/clusternet/clusternet/pkg/utils"
 )
 
 // CRRApprover defines configuration for ClusterRegistrationRequests approver
@@ -97,7 +97,7 @@ func (crrApprover *CRRApprover) applyDefaultRBACRules() {
 			klog.V(5).Infof("ensure ClusterRole %q...", cr.Name)
 			// make sure this clusterrole gets initialized before we go next
 			for {
-				err := ensureClusterRole(crrApprover.ctx, cr, crrApprover.kubeclient, retry.DefaultBackoff)
+				err := utils.EnsureClusterRole(crrApprover.ctx, cr, crrApprover.kubeclient, retry.DefaultBackoff)
 				if err == nil {
 					break
 				}
@@ -400,7 +400,7 @@ func (crrApprover *CRRApprover) bindingClusterRolesIfNeeded(serviceAccountName, 
 	for _, clusterrole := range clusterRoles {
 		go func(cr rbacv1.ClusterRole) {
 			defer wg.Done()
-			err := ensureClusterRole(crrApprover.ctx, cr, crrApprover.kubeclient, retry.DefaultRetry)
+			err := utils.EnsureClusterRole(crrApprover.ctx, cr, crrApprover.kubeclient, retry.DefaultRetry)
 			if err != nil {
 				allErrs = append(allErrs, fmt.Errorf("failed to ensure ClusterRole %q: %v", cr.Name, err))
 			}
@@ -416,7 +416,7 @@ func (crrApprover *CRRApprover) bindingClusterRolesIfNeeded(serviceAccountName, 
 	for _, clusterrole := range clusterRoles {
 		go func(cr rbacv1.ClusterRole) {
 			defer wg.Done()
-			err := ensureClusterRoleBinding(crrApprover.ctx, rbacv1.ClusterRoleBinding{
+			err := utils.EnsureClusterRoleBinding(crrApprover.ctx, rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        cr.Name,
 					Annotations: map[string]string{known.AutoUpdateAnnotationKey: "true"},
@@ -451,7 +451,7 @@ func (crrApprover *CRRApprover) bindingRoleIfNeeded(serviceAccountName, namespac
 	for _, role := range roles {
 		go func(r rbacv1.Role) {
 			defer wg.Done()
-			err := ensureRole(crrApprover.ctx, r, crrApprover.kubeclient, retry.DefaultRetry)
+			err := utils.EnsureRole(crrApprover.ctx, r, crrApprover.kubeclient, retry.DefaultRetry)
 			if err != nil {
 				allErrs = append(allErrs, fmt.Errorf("failed to ensure Role %q: %v", r.Name, err))
 			}
@@ -468,7 +468,7 @@ func (crrApprover *CRRApprover) bindingRoleIfNeeded(serviceAccountName, namespac
 	for _, role := range roles {
 		go func(r rbacv1.Role) {
 			defer wg.Done()
-			err := ensureRoleBinding(crrApprover.ctx, rbacv1.RoleBinding{
+			err := utils.EnsureRoleBinding(crrApprover.ctx, rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        r.Name,
 					Namespace:   r.Namespace,
@@ -491,135 +491,6 @@ func (crrApprover *CRRApprover) bindingRoleIfNeeded(serviceAccountName, namespac
 
 	wg.Wait()
 	return utilerrors.NewAggregate(allErrs)
-}
-
-// ensureClusterRole will make sure desired clusterrole exists and update the rules if available
-func ensureClusterRole(ctx context.Context, clusterrole rbacv1.ClusterRole, client *kubernetes.Clientset, backoff wait.Backoff) error {
-	klog.V(5).Infof("ensure ClusterRole %s...", clusterrole.Name)
-	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (bool, error) {
-		_, err := client.RbacV1().ClusterRoles().Create(ctx, &clusterrole, metav1.CreateOptions{})
-		if err == nil {
-			// success on the creating
-			return true, nil
-		}
-		if !errors.IsAlreadyExists(err) {
-			klog.Errorf("failed to create ClusterRole %s: %v, will retry", clusterrole.Name, err)
-			return false, nil
-		}
-
-		// try to auto update existing object
-		cr, err := client.RbacV1().ClusterRoles().Get(ctx, clusterrole.Name, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("failed to get ClusterRole %s: %v, will retry", clusterrole.Name, err)
-			return false, nil
-		}
-		if autoUpdate, ok := cr.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
-			_, err = client.RbacV1().ClusterRoles().Update(ctx, &clusterrole, metav1.UpdateOptions{})
-			if err == nil {
-				// success on the updating
-				return true, nil
-			}
-			klog.Errorf("failed to update ClusterRole %s: %v, will retry", clusterrole.Name, err)
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func ensureClusterRoleBinding(ctx context.Context, clusterrolebinding rbacv1.ClusterRoleBinding, client *kubernetes.Clientset, backoff wait.Backoff) error {
-	klog.V(5).Infof("ensure ClusterRoleBinding %s...", clusterrolebinding.Name)
-	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (bool, error) {
-		_, err := client.RbacV1().ClusterRoleBindings().Create(ctx, &clusterrolebinding, metav1.CreateOptions{})
-		if err == nil {
-			// success on the creating
-			return true, nil
-		}
-		if !errors.IsAlreadyExists(err) {
-			klog.Errorf("failed to create ClusterRoleBinding %s: %v, will retry", clusterrolebinding.Name, err)
-			return false, nil
-		}
-
-		// try to auto update existing object
-		crb, err := client.RbacV1().ClusterRoleBindings().Get(ctx, clusterrolebinding.Name, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("failed to get ClusterRoleBinding %s: %v, will retry", clusterrolebinding.Name, err)
-			return false, nil
-		}
-		if autoUpdate, ok := crb.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
-			_, err = client.RbacV1().ClusterRoleBindings().Update(ctx, &clusterrolebinding, metav1.UpdateOptions{})
-			if err == nil {
-				// success on the updating
-				return true, nil
-			}
-			klog.Errorf("failed to update ClusterRoleBinding %s: %v, will retry", clusterrolebinding.Name, err)
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func ensureRole(ctx context.Context, role rbacv1.Role, client *kubernetes.Clientset, backoff wait.Backoff) error {
-	klog.V(5).Infof("ensure Role %s/%s...", role.Namespace, role.Name)
-	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (bool, error) {
-		_, err := client.RbacV1().Roles(role.Namespace).Create(ctx, &role, metav1.CreateOptions{})
-		if err == nil {
-			// success on the creating
-			return true, nil
-		}
-		if !errors.IsAlreadyExists(err) {
-			klog.ErrorDepth(4, fmt.Errorf("failed to create Role %s/%s: %v, will retry", role.Namespace, role.Name, err))
-			return false, nil
-		}
-
-		// try to auto update existing object
-		r, err := client.RbacV1().Roles(role.Namespace).Get(ctx, role.Name, metav1.GetOptions{})
-		if err != nil {
-			klog.ErrorDepth(4, fmt.Errorf("failed to get Role %s/%s: %v, will retry", role.Namespace, role.Name, err))
-			return false, nil
-		}
-		if autoUpdate, ok := r.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
-			_, err = client.RbacV1().Roles(role.Namespace).Update(ctx, &role, metav1.UpdateOptions{})
-			if err == nil {
-				// success on the updating
-				return true, nil
-			}
-			klog.ErrorDepth(4, fmt.Sprintf("failed to update Role %s/%s: %v, will retry", role.Namespace, role.Name, err))
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func ensureRoleBinding(ctx context.Context, rolebinding rbacv1.RoleBinding, client *kubernetes.Clientset, backoff wait.Backoff) error {
-	klog.V(5).Infof("ensure RoleBinding %s/%s...", rolebinding.Namespace, rolebinding.Name)
-	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (done bool, err error) {
-		_, err = client.RbacV1().RoleBindings(rolebinding.Namespace).Create(ctx, &rolebinding, metav1.CreateOptions{})
-		if err == nil {
-			// success on the creating
-			return true, nil
-		}
-		if !errors.IsAlreadyExists(err) {
-			klog.Errorf("failed to create RoleBinding %s/%s: %v, will retry", rolebinding.Namespace, rolebinding.Name, err)
-			return false, nil
-		}
-
-		// try to auto update existing object
-		rb, err := client.RbacV1().RoleBindings(rolebinding.Namespace).Get(ctx, rolebinding.Name, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("failed to get RoleBinding %s/%s: %v, will retry", rolebinding.Namespace, rolebinding.Name, err)
-			return false, nil
-		}
-		if autoUpdate, ok := rb.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
-			_, err = client.RbacV1().RoleBindings(rolebinding.Namespace).Update(ctx, &rolebinding, metav1.UpdateOptions{})
-			if err == nil {
-				// success on the updating
-				return true, nil
-			}
-			klog.Errorf("failed to update RoleBinding %s/%s: %v, will retry", rolebinding.Namespace, rolebinding.Name, err)
-			return false, nil
-		}
-		return true, nil
-	})
 }
 
 func getCredentialsForChildCluster(ctx context.Context, client *kubernetes.Clientset, backoff wait.Backoff, saName, saNamespace string) (*corev1.Secret, error) {

--- a/pkg/hub/approver/approver.go
+++ b/pkg/hub/approver/approver.go
@@ -215,7 +215,7 @@ func (crrApprover *CRRApprover) handleClusterRegistrationRequests(crr *clusterap
 
 	// 2. create ManagedCluster object
 	klog.V(5).Infof("create corresponding MangedCluster for cluster %q (%q) if needed", crr.Spec.ClusterID, crr.Spec.ClusterName)
-	mc, err := crrApprover.createManagedClusterIfNeeded(ns.Name, crr.Spec.ClusterName, crr.Spec.ClusterID, crr.Spec.ClusterType)
+	mc, err := crrApprover.createManagedClusterIfNeeded(ns.Name, crr.Spec.ClusterName, crr.Spec.ClusterID, crr.Spec.ClusterType, crr.Spec.SyncMode)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,8 @@ func (crrApprover *CRRApprover) createNamespaceForChildClusterIfNeeded(clusterID
 	return newNs, nil
 }
 
-func (crrApprover *CRRApprover) createManagedClusterIfNeeded(namespace, clusterName string, clusterID types.UID, clusterType clusterapi.ClusterType) (*clusterapi.ManagedCluster, error) {
+func (crrApprover *CRRApprover) createManagedClusterIfNeeded(namespace, clusterName string, clusterID types.UID,
+	clusterType clusterapi.ClusterType, clusterSyncMode clusterapi.ClusterSyncMode) (*clusterapi.ManagedCluster, error) {
 	// checks for a existed ManagedCluster object
 	// the clusterName here may vary, we use clusterID as the identifier
 	mcs, err := crrApprover.clusternetclient.ClustersV1beta1().ManagedClusters(namespace).List(crrApprover.ctx, metav1.ListOptions{
@@ -334,6 +335,7 @@ func (crrApprover *CRRApprover) createManagedClusterIfNeeded(namespace, clusterN
 		Spec: clusterapi.ManagedClusterSpec{
 			ClusterID:   clusterID,
 			ClusterType: clusterType,
+			SyncMode:    clusterSyncMode,
 		},
 	}
 

--- a/pkg/known/annotations.go
+++ b/pkg/known/annotations.go
@@ -19,5 +19,5 @@ package known
 // annotations
 const (
 	// AutoUpdateAnnotationKey is the name of an annotation which prevents reconciliation if set to "false"
-	AutoUpdateAnnotationKey = "clusters.clusternet.io/rbac-autoupdate"
+	AutoUpdateAnnotationKey = "clusternet.io/autoupdate"
 )

--- a/pkg/utils/rbac.go
+++ b/pkg/utils/rbac.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/clusternet/clusternet/pkg/known"
+)
+
+// EnsureClusterRole will make sure desired clusterrole exists and update it if available
+func EnsureClusterRole(ctx context.Context, clusterrole v1.ClusterRole, client *kubernetes.Clientset, backoff wait.Backoff) error {
+	klog.V(5).Infof("ensure ClusterRole %s...", clusterrole.Name)
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (bool, error) {
+		_, err := client.RbacV1().ClusterRoles().Create(ctx, &clusterrole, metav1.CreateOptions{})
+		if err == nil {
+			// success on the creating
+			return true, nil
+		}
+		if !errors.IsAlreadyExists(err) {
+			klog.Errorf("failed to create ClusterRole %s: %v, will retry", clusterrole.Name, err)
+			return false, nil
+		}
+
+		// try to auto update existing object
+		cr, err := client.RbacV1().ClusterRoles().Get(ctx, clusterrole.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("failed to get ClusterRole %s: %v, will retry", clusterrole.Name, err)
+			return false, nil
+		}
+		if autoUpdate, ok := cr.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
+			_, err = client.RbacV1().ClusterRoles().Update(ctx, &clusterrole, metav1.UpdateOptions{})
+			if err == nil {
+				// success on the updating
+				return true, nil
+			}
+			klog.Errorf("failed to update ClusterRole %s: %v, will retry", clusterrole.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// EnsureClusterRoleBinding will make sure desired clusterrolebinding exists and update it if available
+func EnsureClusterRoleBinding(ctx context.Context, clusterrolebinding v1.ClusterRoleBinding, client *kubernetes.Clientset, backoff wait.Backoff) error {
+	klog.V(5).Infof("ensure ClusterRoleBinding %s...", clusterrolebinding.Name)
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (bool, error) {
+		_, err := client.RbacV1().ClusterRoleBindings().Create(ctx, &clusterrolebinding, metav1.CreateOptions{})
+		if err == nil {
+			// success on the creating
+			return true, nil
+		}
+		if !errors.IsAlreadyExists(err) {
+			klog.Errorf("failed to create ClusterRoleBinding %s: %v, will retry", clusterrolebinding.Name, err)
+			return false, nil
+		}
+
+		// try to auto update existing object
+		crb, err := client.RbacV1().ClusterRoleBindings().Get(ctx, clusterrolebinding.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("failed to get ClusterRoleBinding %s: %v, will retry", clusterrolebinding.Name, err)
+			return false, nil
+		}
+		if autoUpdate, ok := crb.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
+			_, err = client.RbacV1().ClusterRoleBindings().Update(ctx, &clusterrolebinding, metav1.UpdateOptions{})
+			if err == nil {
+				// success on the updating
+				return true, nil
+			}
+			klog.Errorf("failed to update ClusterRoleBinding %s: %v, will retry", clusterrolebinding.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// EnsureRole will make sure desired role exists and update it if available
+func EnsureRole(ctx context.Context, role v1.Role, client *kubernetes.Clientset, backoff wait.Backoff) error {
+	klog.V(5).Infof("ensure Role %s/%s...", role.Namespace, role.Name)
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (bool, error) {
+		_, err := client.RbacV1().Roles(role.Namespace).Create(ctx, &role, metav1.CreateOptions{})
+		if err == nil {
+			// success on the creating
+			return true, nil
+		}
+		if !errors.IsAlreadyExists(err) {
+			klog.ErrorDepth(4, fmt.Errorf("failed to create Role %s/%s: %v, will retry", role.Namespace, role.Name, err))
+			return false, nil
+		}
+
+		// try to auto update existing object
+		r, err := client.RbacV1().Roles(role.Namespace).Get(ctx, role.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.ErrorDepth(4, fmt.Errorf("failed to get Role %s/%s: %v, will retry", role.Namespace, role.Name, err))
+			return false, nil
+		}
+		if autoUpdate, ok := r.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
+			_, err = client.RbacV1().Roles(role.Namespace).Update(ctx, &role, metav1.UpdateOptions{})
+			if err == nil {
+				// success on the updating
+				return true, nil
+			}
+			klog.ErrorDepth(4, fmt.Sprintf("failed to update Role %s/%s: %v, will retry", role.Namespace, role.Name, err))
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// EnsureRoleBinding will make sure desired rolebinding exists and update it if available
+func EnsureRoleBinding(ctx context.Context, rolebinding v1.RoleBinding, client *kubernetes.Clientset, backoff wait.Backoff) error {
+	klog.V(5).Infof("ensure RoleBinding %s/%s...", rolebinding.Namespace, rolebinding.Name)
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func() (done bool, err error) {
+		_, err = client.RbacV1().RoleBindings(rolebinding.Namespace).Create(ctx, &rolebinding, metav1.CreateOptions{})
+		if err == nil {
+			// success on the creating
+			return true, nil
+		}
+		if !errors.IsAlreadyExists(err) {
+			klog.Errorf("failed to create RoleBinding %s/%s: %v, will retry", rolebinding.Namespace, rolebinding.Name, err)
+			return false, nil
+		}
+
+		// try to auto update existing object
+		rb, err := client.RbacV1().RoleBindings(rolebinding.Namespace).Get(ctx, rolebinding.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("failed to get RoleBinding %s/%s: %v, will retry", rolebinding.Namespace, rolebinding.Name, err)
+			return false, nil
+		}
+		if autoUpdate, ok := rb.Annotations[known.AutoUpdateAnnotationKey]; ok && autoUpdate == "true" {
+			_, err = client.RbacV1().RoleBindings(rolebinding.Namespace).Update(ctx, &rolebinding, metav1.UpdateOptions{})
+			if err == nil {
+				// success on the updating
+				return true, nil
+			}
+			klog.Errorf("failed to update RoleBinding %s/%s: %v, will retry", rolebinding.Namespace, rolebinding.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
- introducing a new field `--sync-cluster-mode` for `clusternet-agent`;
- add a new field `SyncMode` to `ClusterRegistrationRequest` and `ManagedCluster`;
- a new secret named `child-cluster-deployer` is auto-created in the dedicated namespace for the child cluster, which can be used by `clusternet-hub` when deploying resources to child cluster;

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

- annotation key `clusters.clusternet.io/rbac-autoupdate` is changed to `clusternet.io/autoupdate`
- secret data key `parent-url` is changed to `apiserver-advertise-url`
