### PR TITLE
add finalizer for secret child-cluster-deployer

### DIFF
--- a/pkg/agent/deployer.go
+++ b/pkg/agent/deployer.go
@@ -115,11 +115,15 @@ func createDeployerCredentialsToParentCluster(ctx context.Context, parentClientS
 			Name:      known.ChildClusterSecretName,
 			Namespace: dedicatedNamespace,
 			Labels: map[string]string{
-				known.ClusterRegisteredByLabel: known.ClusternetAgentName,
-				known.ClusterIDLabel:           clusterID,
+				known.ObjectCreatedByLabel:      known.ClusternetAgentName,
+				known.ClusterIDLabel:            clusterID,
+				known.ClusterBootstrappingLabel: known.CredentialsAuto,
 			},
 			Annotations: map[string]string{
 				known.AutoUpdateAnnotationKey: "true",
+			},
+			Finalizers: []string{
+				known.AppFinalizer,
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/controllers/misc/secret/secret.go
+++ b/pkg/controllers/misc/secret/secret.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreInformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	coreListers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/clusternet/clusternet/pkg/known"
+	"github.com/clusternet/clusternet/pkg/utils"
+)
+
+// controllerKind contains the schema.GroupVersionKind for this controller type.
+var controllerKind = coreapi.SchemeGroupVersion.WithKind("Secret")
+
+type SyncHandlerFunc func(secret *coreapi.Secret) error
+
+// Controller is a controller that handle Secret
+// here we only foucs on Secret "child-cluster-deployer" !!!
+type Controller struct {
+	ctx context.Context
+
+	kubeclient kubernetes.Interface
+
+	// workqueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens. This
+	// means we can ensure we only process a fixed amount of resources at a
+	// time, and makes it easy to ensure we are never processing the same item
+	// simultaneously in two different workers.
+	workqueue workqueue.RateLimitingInterface
+
+	secretLister coreListers.SecretLister
+	secretSynced cache.InformerSynced
+
+	SyncHandler SyncHandlerFunc
+}
+
+func NewController(ctx context.Context, kubeclient kubernetes.Interface,
+	secretInformer coreInformers.SecretInformer, syncHandler SyncHandlerFunc) (*Controller, error) {
+	if syncHandler == nil {
+		return nil, fmt.Errorf("syncHandler must be set")
+	}
+
+	c := &Controller{
+		ctx:          ctx,
+		kubeclient:   kubeclient,
+		workqueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secret"),
+		secretLister: secretInformer.Lister(),
+		secretSynced: secretInformer.Informer().HasSynced,
+		SyncHandler:  syncHandler,
+	}
+
+	// Manage the addition/update of Secret
+	// here we only foucs on Secret "child-cluster-deployer" !!!
+	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addSecret,
+		UpdateFunc: c.updateSecret,
+		DeleteFunc: c.deleteSecret,
+	})
+
+	return c, nil
+}
+
+// Run will set up the event handlers for types we are interested in, as well
+// as syncing informer caches and starting workers. It will block until stopCh
+// is closed, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	klog.Info("starting Secret controller...")
+	defer klog.Info("shutting down Secret controller")
+
+	// Wait for the caches to be synced before starting workers
+	klog.V(5).Info("waiting for informer caches to sync")
+	if !cache.WaitForCacheSync(stopCh, c.secretSynced) {
+		return
+	}
+
+	klog.V(5).Infof("starting %d worker threads", workers)
+	// Launch workers to process Secret resources
+	for i := 0; i < workers; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (c *Controller) addSecret(obj interface{}) {
+	secret := obj.(*coreapi.Secret)
+
+	if secret.Name != known.ChildClusterSecretName {
+		return
+	}
+
+	// add finalizer
+	if secret.DeletionTimestamp == nil {
+		if !utils.ContainsString(secret.Finalizers, known.AppFinalizer) {
+			secret.Finalizers = append(secret.Finalizers, known.AppFinalizer)
+		}
+		_, err := c.kubeclient.CoreV1().Secrets(secret.Namespace).Update(context.TODO(),
+			secret, metav1.UpdateOptions{})
+		if err == nil {
+			msg := fmt.Sprintf("successfully inject finalizer %s to Secret %s", known.AppFinalizer, klog.KObj(secret))
+			klog.V(4).Info(msg)
+			return
+		} else {
+			klog.WarningDepth(4,
+				fmt.Sprintf("failed to inject finalizer %s to Secret %s: %v", known.AppFinalizer, klog.KObj(secret), err))
+			c.addSecret(obj)
+			return
+		}
+	}
+
+	c.enqueue(secret)
+}
+
+func (c *Controller) updateSecret(old, cur interface{}) {
+	secret := cur.(*coreapi.Secret)
+	if secret.Name != known.ChildClusterSecretName {
+		return
+	}
+
+	if secret.DeletionTimestamp != nil {
+		c.enqueue(secret)
+		return
+	}
+}
+
+func (c *Controller) deleteSecret(obj interface{}) {
+	secret, ok := obj.(*coreapi.Secret)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return
+		}
+		_, ok = tombstone.Obj.(*coreapi.Secret)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Secret %#v", obj))
+			return
+		}
+	}
+
+	if secret.Name != known.ChildClusterSecretName {
+		return
+	}
+
+	klog.V(4).Infof("deleting Secret %q", klog.KObj(secret))
+	c.enqueue(secret)
+}
+
+// runWorker is a long-running function that will continually call the
+// processNextWorkItem function in order to read and process a message on the
+// workqueue.
+func (c *Controller) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem will read a single work item off the workqueue and
+// attempt to process it, by calling the syncHandler.
+func (c *Controller) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	// We wrap this block in a func so we can defer c.workqueue.Done.
+	err := func(obj interface{}) error {
+		// We call Done here so the workqueue knows we have finished
+		// processing this item. We also must remember to call Forget if we
+		// do not want this work item being re-queued. For example, we do
+		// not call Forget if a transient error occurs, instead the item is
+		// put back on the workqueue and attempted again after a back-off
+		// period.
+		defer c.workqueue.Done(obj)
+		var key string
+		var ok bool
+		// We expect strings to come off the workqueue. These are of the
+		// form namespace/name. We do this as the delayed nature of the
+		// workqueue means the items in the informer cache may actually be
+		// more up to date that when the item was initially put onto the
+		// workqueue.
+		if key, ok = obj.(string); !ok {
+			// As the item in the workqueue is actually invalid, we call
+			// Forget here else we'd go into a loop of attempting to
+			// process a work item that is invalid.
+			c.workqueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		// Run the syncHandler, passing it the namespace/name string of the
+		// Secret resource to be synced.
+		if err := c.syncHandler(key); err != nil {
+			// Put the item back on the workqueue to handle any transient errors.
+			c.workqueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+		// Finally, if no error occurs we Forget this item so it does not
+		// get queued again until another change happens.
+		c.workqueue.Forget(obj)
+		klog.Infof("successfully synced Secret %q", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+// syncHandler compares the actual state with the desired, and attempts to
+// converge the two. It then updates the Status block of the Secret resource
+// with the current status of the resource.
+func (c *Controller) syncHandler(key string) error {
+	// If an error occurs during handling, we'll requeue the item so we can
+	// attempt processing again later. This could have been caused by a
+	// temporary network failure, or any other transient reason.
+
+	// Convert the namespace/name string into a distinct namespace and name
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	klog.V(4).Infof("start processing Secret %q", key)
+	// Get the Secret resource with this name
+	secret, err := c.secretLister.Secrets(ns).Get(name)
+	// The Secret resource may no longer exist, in which case we stop processing.
+	if errors.IsNotFound(err) {
+		klog.V(2).Infof("Secret %q has been deleted", key)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	secret.Kind = controllerKind.Kind
+	secret.APIVersion = controllerKind.Version
+
+	return c.SyncHandler(secret)
+}
+
+// enqueue takes a Secret resource and converts it into a namespace/name
+// string which is then put onto the work queue. This method should *not* be
+// passed resources of any type other than Secret.
+func (c *Controller) enqueue(secret *coreapi.Secret) {
+	key, err := cache.MetaNamespaceKeyFunc(secret)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	c.workqueue.Add(key)
+}

--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -96,7 +96,7 @@ func NewDeployer(ctx context.Context, kubeclient *kubernetes.Clientset, clustern
 	}
 	deployer.recorder = deployer.broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "clusternet-hub"})
 
-	helmDeployer, err := helm.NewHelmDeployer(ctx, clusternetclient, clusternetInformerFactory, kubeInformerFactory, deployer.recorder)
+	helmDeployer, err := helm.NewHelmDeployer(ctx, clusternetclient, kubeclient, clusternetInformerFactory, kubeInformerFactory, deployer.recorder)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hub/deployer/helm/helm.go
+++ b/pkg/hub/deployer/helm/helm.go
@@ -29,8 +29,10 @@ import (
 	"helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kubeInformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	corev1Lister "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -39,6 +41,7 @@ import (
 	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
 	"github.com/clusternet/clusternet/pkg/controllers/apps/helmchart"
 	"github.com/clusternet/clusternet/pkg/controllers/apps/helmrelease"
+	"github.com/clusternet/clusternet/pkg/controllers/misc/secret"
 	clusternetClientSet "github.com/clusternet/clusternet/pkg/generated/clientset/versioned"
 	clusternetInformers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions"
 	appListers "github.com/clusternet/clusternet/pkg/generated/listers/apps/v1alpha1"
@@ -56,7 +59,10 @@ type HelmDeployer struct {
 	helmChartController   *helmchart.Controller
 	helmReleaseController *helmrelease.Controller
 
+	secretController *secret.Controller
+
 	clusternetclient *clusternetClientSet.Clientset
+	kubeclient       *kubernetes.Clientset
 
 	chartLister appListers.HelmChartLister
 	hrLister    appListers.HelmReleaseLister
@@ -66,7 +72,8 @@ type HelmDeployer struct {
 	recorder record.EventRecorder
 }
 
-func NewHelmDeployer(ctx context.Context, clusternetclient *clusternetClientSet.Clientset,
+func NewHelmDeployer(ctx context.Context,
+	clusternetclient *clusternetClientSet.Clientset, kubeclient *kubernetes.Clientset,
 	clusternetInformerFactory clusternetInformers.SharedInformerFactory,
 	kubeInformerFactory kubeInformers.SharedInformerFactory,
 	recorder record.EventRecorder) (*HelmDeployer, error) {
@@ -74,6 +81,7 @@ func NewHelmDeployer(ctx context.Context, clusternetclient *clusternetClientSet.
 	hd := &HelmDeployer{
 		ctx:              ctx,
 		clusternetclient: clusternetclient,
+		kubeclient:       kubeclient,
 		chartLister:      clusternetInformerFactory.Apps().V1alpha1().HelmCharts().Lister(),
 		hrLister:         clusternetInformerFactory.Apps().V1alpha1().HelmReleases().Lister(),
 		secretLister:     kubeInformerFactory.Core().V1().Secrets().Lister(),
@@ -96,6 +104,15 @@ func NewHelmDeployer(ctx context.Context, clusternetclient *clusternetClientSet.
 	}
 	hd.helmReleaseController = hrController
 
+	secretController, err := secret.NewController(ctx,
+		kubeclient,
+		kubeInformerFactory.Core().V1().Secrets(),
+		hd.handleSecret)
+	if err != nil {
+		return nil, err
+	}
+	hd.secretController = secretController
+
 	return hd, nil
 }
 
@@ -105,6 +122,8 @@ func (hd *HelmDeployer) Run(workers int) {
 
 	go hd.helmChartController.Run(workers, hd.ctx.Done())
 	go hd.helmReleaseController.Run(workers, hd.ctx.Done())
+	// 1 worker may get hang up, so we set minimum 2 workers here
+	go hd.secretController.Run(2, hd.ctx.Done())
 
 	<-hd.ctx.Done()
 }
@@ -307,4 +326,32 @@ func (hd *HelmDeployer) handleHelmRelease(hr *appsapi.HelmRelease) error {
 	}
 
 	return hd.helmReleaseController.UpdateHelmReleaseStatus(hr, status)
+}
+
+func (hd *HelmDeployer) handleSecret(secret *corev1.Secret) error {
+	if secret.DeletionTimestamp == nil {
+		return nil
+	}
+
+	if secret.Name != known.ChildClusterSecretName {
+		return nil
+	}
+
+	// check wether HelmReleases get cleaned up
+	hrs, err := hd.hrLister.HelmReleases(secret.Namespace).List(labels.SelectorFromSet(labels.Set{}))
+	if err != nil {
+		return err
+	}
+
+	if len(hrs) > 0 {
+		return fmt.Errorf("waiting all HelmReleases in namespace %s get cleanedup", secret.Namespace)
+	}
+
+	secret.Finalizers = utils.RemoveString(secret.Finalizers, known.AppFinalizer)
+	_, err = hd.kubeclient.CoreV1().Secrets(secret.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	if err != nil {
+		klog.WarningDepth(4,
+			fmt.Sprintf("failed to remove finalizer %s from Secrets %s: %v", known.AppFinalizer, klog.KObj(secret), err))
+	}
+	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
When a namespace gets deleted, all secrets will be deleted as well. But secret `child-cluster-deployer` will be used when uninstalling/deleting a HelmRelease. So a finalizer `apps.clusternet.io/finalizer` is added for secret `child-cluster-deployer` upon creating and removed after all HelmReleases get deleted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
