### PR TITLE
compatible empty clusterID when listing ManagedCluster

### DIFF
--- a/pkg/hub/deployer/generic/generic.go
+++ b/pkg/hub/deployer/generic/generic.go
@@ -110,10 +110,12 @@ func (deployer *Deployer) handleDescription(desc *appsapi.Description) error {
 	}
 
 	// check whether ManagedCluster will enable deploying Description with Pusher/Dual mode
+	labelSet := labels.Set{}
+	if len(desc.Labels[known.ClusterIDLabel]) > 0 {
+		labelSet[known.ClusterIDLabel] = desc.Labels[known.ClusterIDLabel]
+	}
 	mcls, err := deployer.clusterLister.ManagedClusters(desc.Namespace).List(
-		labels.SelectorFromSet(labels.Set{
-			known.ClusterIDLabel: desc.Labels[known.ClusterIDLabel],
-		}))
+		labels.SelectorFromSet(labelSet))
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/deployer/helm/helm.go
+++ b/pkg/hub/deployer/helm/helm.go
@@ -153,10 +153,12 @@ func (deployer *Deployer) handleDescription(desc *appsapi.Description) error {
 
 	// TODO: may ignore checking AppPusher for helm charts?
 	// check whether ManagedCluster will enable deploying Description with Pusher/Dual mode
+	labelSet := labels.Set{}
+	if len(desc.Labels[known.ClusterIDLabel]) > 0 {
+		labelSet[known.ClusterIDLabel] = desc.Labels[known.ClusterIDLabel]
+	}
 	mcls, err := deployer.clusterLister.ManagedClusters(desc.Namespace).List(
-		labels.SelectorFromSet(labels.Set{
-			known.ClusterIDLabel: desc.Labels[known.ClusterIDLabel],
-		}))
+		labels.SelectorFromSet(labelSet))
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/kubeconfig.go
+++ b/pkg/utils/kubeconfig.go
@@ -140,10 +140,13 @@ func GetChildClusterConfig(secretLister corev1lister.SecretLister, clusterLister
 		return nil, err
 	}
 
+	labelSet := labels.Set{}
+	if len(clusterID) > 0 {
+		labelSet[known.ClusterIDLabel] = clusterID
+	}
+
 	mcls, err := clusterLister.ManagedClusters(namespace).List(
-		labels.SelectorFromSet(labels.Set{
-			known.ClusterIDLabel: clusterID,
-		}))
+		labels.SelectorFromSet(labelSet))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
Only add nonempty clusterID into label selector when listing `ManagedCluster`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
