### PR TITLE
update README: PARENTURL also support port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ $ # here we use the token created above
 $ PARENTURL=https://192.168.10.10 REGTOKEN=07401b.f395accd246ae52d envsubst < ./deploy/templates/clusternet_agent_secret.yaml | kubectl apply -f -
 ```
 
-The `PARENTURL` above is the apiserver address of the parent cluster that you want to register to.
+The `PARENTURL` above is the apiserver address of the parent cluster that you want to register to, the `https` scheme must be specified and it is the only one supported at the moment. If the apiserver is not listening on the standard https port (:443), please specify the port number in the URL to ensure the agent connects to the right endpoint, for instance, `https://192.168.10.10:6443`.
 
 ```bash
 $ # before deploying, you could update the SyncMode if needed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

kind/doc

#### What this PR does / why we need it:

In non-production or development kubernetes environments, the port numbers of apiserver are usually not the standard https `:443`, so update the README document to explicitly tell people that `PARENTURL` supports port number.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
