### PR TITLE
remove redundant objects when subscription changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Clusternet is multiple platforms supported now, including
 
 - [Architecture](#architecture)
 - [Concepts](#concepts)
-- [Contributing & Developing](#contributing-developing)
+- [Contributing & Developing](#contributing--developing)
 - [Getting Started](#getting-started)
     - [Deploying Clusternet](#deploying-clusternet)
         - [Deploying `clusternet-hub` in parent cluster](#deploying-clusternet-hub-in-parent-cluster)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
When a `Subscription` gets changed, multiple auto-generated objects should be cleaned up if redundant.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
