### PR TITLE
mitigate manifest name with hyphens

### DIFF
--- a/pkg/registry/shadow/template/rest.go
+++ b/pkg/registry/shadow/template/rest.go
@@ -479,6 +479,22 @@ func (r *REST) normalizeRequest(req *clientgorest.Request, namespace string) *cl
 
 func (r *REST) generateNameForManifest(namespace, name string) string {
 	resource, _ := r.getResourceName()
+	// resource is a word ("[a-z]([-a-z0-9]*[a-z0-9])?") without "."
+	// namespace is a word ("[a-z]([-a-z0-9]*[a-z0-9])?") without "."
+	// so we use "." for concatenation
+	if r.namespaced {
+		return fmt.Sprintf("%s.%s.%s", resource, namespace, name)
+	}
+	return fmt.Sprintf("%s.%s", resource, name)
+}
+
+// DEPRECATED
+// use hyphens for concatenation may lead to conflicts, such as
+// - resource "foos" with name "lovely-panda" in namespace "bar"
+// - resource "foos" with name "panda" in namespace "bar-lovely"
+// will map a same Manifest object with name "foos-bar-lovely-panda"
+func (r *REST) generateLegacyNameForManifest(namespace, name string) string {
+	resource, _ := r.getResourceName()
 	if r.namespaced {
 		return fmt.Sprintf("%s-%s-%s", resource, namespace, name)
 	}

--- a/pkg/registry/shadow/template/rest_test.go
+++ b/pkg/registry/shadow/template/rest_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"testing"
+)
+
+func TestRESTGenerateNameForManifest(t *testing.T) {
+	tests := []struct {
+		testCaseName string
+		resourceName string
+		namespace    string
+		namespaced   bool
+		name         string
+		want         string
+	}{
+		{
+			testCaseName: "namespace-scoped resources foos (standard)",
+			resourceName: "foos",
+			namespace:    "kube-system",
+			namespaced:   true,
+			name:         "abc",
+			want:         "foos.kube-system.abc",
+		},
+		{
+			testCaseName: "namespace-scoped resources foos (name with '.' & '-')",
+			resourceName: "foos",
+			namespace:    "kube-system",
+			namespaced:   true,
+			name:         "abc.def-bar",
+			want:         "foos.kube-system.abc.def-bar",
+		},
+
+		{
+			testCaseName: "cluster-scoped resources bars (standard)",
+			resourceName: "bars",
+			namespace:    "kube-system",
+			namespaced:   false,
+			name:         "abc",
+			want:         "bars.abc",
+		},
+		{
+			testCaseName: "cluster-scoped resources bars (name with '.' & '-')",
+			resourceName: "bars",
+			namespace:    "kube-system",
+			namespaced:   false,
+			name:         "abc.def-bar",
+			want:         "bars.abc.def-bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			r := &REST{
+				name:       tt.resourceName,
+				namespaced: tt.namespaced,
+			}
+			if got := r.generateNameForManifest(tt.namespace, tt.name); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:

`Manifest` object name  is formed by the namespaced name key. This will lead to resources declared in different namespaces map the same `Manifest` object.

For example,
A resource `foo` defined in below 2 namespaces,

- resource name `lovely-panda` in namespace `bar`
- resource name `panda` in namespace `bar-lovely`

will map a same `Manifest` object with name `foos-bar-lovely-panda`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
