### PR TITLE
dispatch feeds to new matching clusters

### DIFF
--- a/pkg/controllers/apps/subscription/subscription.go
+++ b/pkg/controllers/apps/subscription/subscription.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,9 +37,12 @@ import (
 	"k8s.io/klog/v2"
 
 	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
 	clusternetclientset "github.com/clusternet/clusternet/pkg/generated/clientset/versioned"
 	appinformers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions/apps/v1alpha1"
+	clusterinformers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions/clusters/v1beta1"
 	applisters "github.com/clusternet/clusternet/pkg/generated/listers/apps/v1alpha1"
+	clusterlisters "github.com/clusternet/clusternet/pkg/generated/listers/clusters/v1beta1"
 	"github.com/clusternet/clusternet/pkg/known"
 	"github.com/clusternet/clusternet/pkg/utils"
 )
@@ -51,6 +56,9 @@ type SyncHandlerFunc func(subscription *appsapi.Subscription) error
 type Controller struct {
 	ctx context.Context
 
+	lock           sync.RWMutex
+	subscribersMap map[string][]appsapi.Subscriber
+
 	clusternetClient clusternetclientset.Interface
 
 	// workqueue is a rate limited work queue. This is used to queue work to be
@@ -60,9 +68,11 @@ type Controller struct {
 	// simultaneously in two different workers.
 	workqueue workqueue.RateLimitingInterface
 
-	subsLister applisters.SubscriptionLister
-	subsSynced cache.InformerSynced
-	baseSynced cache.InformerSynced
+	subsLister    applisters.SubscriptionLister
+	subsSynced    cache.InformerSynced
+	baseSynced    cache.InformerSynced
+	clusterLister clusterlisters.ManagedClusterLister
+	clusterSynced cache.InformerSynced
 
 	recorder record.EventRecorder
 
@@ -71,18 +81,21 @@ type Controller struct {
 
 func NewController(ctx context.Context, clusternetClient clusternetclientset.Interface,
 	subsInformer appinformers.SubscriptionInformer, baseInformer appinformers.BaseInformer,
-	recorder record.EventRecorder, syncHandlerFunc SyncHandlerFunc) (*Controller, error) {
+	clusterInformer clusterinformers.ManagedClusterInformer, recorder record.EventRecorder, syncHandlerFunc SyncHandlerFunc) (*Controller, error) {
 	if syncHandlerFunc == nil {
 		return nil, fmt.Errorf("syncHandlerFunc must be set")
 	}
 
 	c := &Controller{
 		ctx:              ctx,
+		subscribersMap:   make(map[string][]appsapi.Subscriber),
 		clusternetClient: clusternetClient,
 		workqueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "subscription"),
 		subsLister:       subsInformer.Lister(),
 		subsSynced:       subsInformer.Informer().HasSynced,
 		baseSynced:       baseInformer.Informer().HasSynced,
+		clusterLister:    clusterInformer.Lister(),
+		clusterSynced:    clusterInformer.Informer().HasSynced,
 		recorder:         recorder,
 		syncHandlerFunc:  syncHandlerFunc,
 	}
@@ -92,6 +105,12 @@ func NewController(ctx context.Context, clusternetClient clusternetclientset.Int
 		AddFunc:    c.addSubscription,
 		UpdateFunc: c.updateSubscription,
 		DeleteFunc: c.deleteSubscription,
+	})
+
+	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addCluster,
+		UpdateFunc: c.updateCluster,
+		DeleteFunc: c.deleteCluster,
 	})
 
 	baseInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -114,7 +133,11 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 	// Wait for the caches to be synced before starting workers
 	klog.V(5).Info("waiting for informer caches to sync")
-	if !cache.WaitForCacheSync(stopCh, c.subsSynced, c.baseSynced) {
+	if !cache.WaitForCacheSync(stopCh,
+		c.subsSynced,
+		c.baseSynced,
+		c.clusterSynced,
+	) {
 		return
 	}
 
@@ -129,6 +152,11 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
 
 func (c *Controller) addSubscription(obj interface{}) {
 	sub := obj.(*appsapi.Subscription)
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.subscribersMap[klog.KObj(sub).String()] = sub.Spec.Subscribers
+
 	klog.V(4).Infof("adding Subscription %q", klog.KObj(sub))
 	c.enqueue(sub)
 }
@@ -148,6 +176,10 @@ func (c *Controller) updateSubscription(old, cur interface{}) {
 		return
 	}
 
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.subscribersMap[klog.KObj(newSub).String()] = newSub.Spec.Subscribers
+
 	klog.V(4).Infof("updating Subscription %q", klog.KObj(oldSub))
 	c.enqueue(newSub)
 }
@@ -166,6 +198,10 @@ func (c *Controller) deleteSubscription(obj interface{}) {
 			return
 		}
 	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.subscribersMap, klog.KObj(sub).String())
 
 	klog.V(4).Infof("deleting Subscription %q", klog.KObj(sub))
 	c.enqueue(sub)
@@ -208,6 +244,59 @@ func (c *Controller) resolveControllerRef(name, namespace string, uid types.UID)
 		return nil
 	}
 	return sub
+}
+
+func (c *Controller) addCluster(obj interface{}) {
+	mcls := obj.(*clusterapi.ManagedCluster)
+	klog.V(5).Infof("adding ManagedCluster %q", klog.KObj(mcls))
+	c.enqueueSubscriptionForCluster(mcls)
+}
+
+func (c *Controller) updateCluster(old, cur interface{}) {
+	oldMcls := old.(*clusterapi.ManagedCluster)
+	newMcls := cur.(*clusterapi.ManagedCluster)
+
+	if newMcls.DeletionTimestamp != nil {
+		c.deleteCluster(cur)
+		return
+	}
+
+	// Decide whether discovery has reported a label change.
+	if reflect.DeepEqual(oldMcls.Labels, newMcls.Labels) {
+		klog.V(4).Infof("no updates on the labels of ManagedCluster %s, skipping syncing", klog.KObj(oldMcls))
+		return
+	}
+
+	klog.V(5).Infof("updating ManagedCluster %q", klog.KObj(oldMcls))
+	c.enqueueSubscriptionForCluster(newMcls)
+}
+
+func (c *Controller) deleteCluster(obj interface{}) {
+	// when a ManagedCluster is deleted,
+	// - Auto populated objects, like Base and Description, will be auto-deleted on next sync/resync of subscribed Subscriptions
+	// - If current dedicated namespace is deleted, then all objects in this namespaces will be pruned.
+
+	// TODO (dixudx): prune all related objects immediately?
+}
+
+func (c *Controller) enqueueSubscriptionForCluster(mcls *clusterapi.ManagedCluster) {
+	c.lock.RLock()
+	subscribersMap := c.subscribersMap
+	c.lock.RUnlock()
+
+	for key, subscribers := range subscribersMap {
+		for _, subscriber := range subscribers {
+			selector, err := metav1.LabelSelectorAsSelector(subscriber.ClusterAffinity)
+			if err != nil {
+				klog.ErrorDepth(5, fmt.Sprintf("failed to parse labelSelector in Subscription %s: %v", key, err))
+				continue
+			}
+			if selector.Matches(labels.Set(mcls.Labels)) {
+				c.workqueue.Add(key)
+				break
+			}
+		}
+	}
 }
 
 // runWorker is a long-running function that will continually call the

--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -156,6 +156,7 @@ func NewDeployer(ctx context.Context, kubeclient *kubernetes.Clientset, clustern
 		clusternetclient,
 		clusternetInformerFactory.Apps().V1alpha1().Subscriptions(),
 		clusternetInformerFactory.Apps().V1alpha1().Bases(),
+		clusternetInformerFactory.Clusters().V1beta1().ManagedClusters(),
 		deployer.recorder,
 		deployer.handleSubscription)
 	if err != nil {

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -91,6 +91,7 @@ func NewHub(ctx context.Context, opts *options.HubServerOptions) (*Hub, error) {
 	}
 
 	// add informers for minimum requirements
+	// register informers first before informerFactory starts
 	kubeInformerFactory.Core().V1().Namespaces().Informer()
 	kubeInformerFactory.Core().V1().ServiceAccounts().Informer()
 	kubeInformerFactory.Core().V1().Secrets().Informer()
@@ -100,6 +101,7 @@ func NewHub(ctx context.Context, opts *options.HubServerOptions) (*Hub, error) {
 
 	var d *deployer.Deployer
 	if deployerEnabled {
+		// register informers first before informerFactory starts
 		clusternetInformerFactory.Apps().V1alpha1().Manifests().Informer()
 		clusternetInformerFactory.Apps().V1alpha1().Bases().Informer()
 		clusternetInformerFactory.Apps().V1alpha1().Subscriptions().Informer()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
When a new cluster is registered, or clusters are re-matched with updated labels, these clusters should be dispatched with all matching Subscriptions.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
