### PR TITLE
comment out checking cluster type on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ metadata:
 spec:
   clusterId: dc91021d-2361-4f6d-a404-7c33b9e01118
   clusterName: clusternet-cluster-dzqkw
-  clusterType: EdgeClusterSelfProvisioned
+  clusterType: EdgeCluster
 status:
   caCertificate: REDACTED
   dedicatedNamespace: clusternet-dhxfs
@@ -263,8 +263,8 @@ $ # mcls is an alias for ManagedCluster
 $ # kubectl get mcls -A
 $ # or append "-o wide" to display extra columns
 $ kubectl get mcls -A -o wide
-NAMESPACE          NAME                       CLUSTER ID                             CLUSTER TYPE                 SYNC MODE   KUBERNETES   READYZ   AGE
-clusternet-dhxfs   clusternet-cluster-dzqkw   dc91021d-2361-4f6d-a404-7c33b9e01118   EdgeClusterSelfProvisioned   Dual        v1.19.10     true     7d23h
+NAMESPACE          NAME                       CLUSTER ID                             CLUSTER TYPE   SYNC MODE   KUBERNETES   READYZ   AGE
+clusternet-dhxfs   clusternet-cluster-dzqkw   dc91021d-2361-4f6d-a404-7c33b9e01118   EdgeCluster    Dual        v1.19.10     true     7d23h
 $ kubectl get mcls -n clusternet-dhxfs   clusternet-cluster-dzqkw -o yaml
 apiVersion: clusters.clusternet.io/v1beta1
 kind: ManagedCluster
@@ -277,7 +277,7 @@ metadata:
   namespace: clusternet-dhxfs
 spec:
   clusterId: dc91021d-2361-4f6d-a404-7c33b9e01118
-  clusterType: EdgeClusterSelfProvisioned
+  clusterType: EdgeCluster
   syncMode: Dual
 status:
   apiserverURL: http://10.0.0.10:8080

--- a/pkg/agent/option.go
+++ b/pkg/agent/option.go
@@ -22,11 +22,9 @@ import (
 	"regexp"
 	"strings"
 
+	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
 )
 
 var validateClusterNameRegex = regexp.MustCompile(nameFmt)
@@ -60,7 +58,7 @@ type ClusterRegistrationOptions struct {
 func NewClusterRegistrationOptions() *ClusterRegistrationOptions {
 	return &ClusterRegistrationOptions{
 		ClusterNamePrefix:             RegistrationNamePrefix,
-		ClusterType:                   string(clusterapi.EdgeClusterSelfProvisioned),
+		ClusterType:                   string(clusterapi.EdgeCluster),
 		ClusterSyncMode:               string(clusterapi.Pull),
 		ClusterStatusReportFrequency:  metav1.Duration{Duration: DefaultClusterStatusReportFrequency},
 		ClusterStatusCollectFrequency: metav1.Duration{Duration: DefaultClusterStatusCollectFrequency},
@@ -124,10 +122,11 @@ func (opts *ClusterRegistrationOptions) Validate() []error {
 		}
 	}
 
-	if len(opts.ClusterType) > 0 && !supportedClusterTypes.Has(opts.ClusterType) {
-		allErrs = append(allErrs, fmt.Errorf("invalid cluster type %q, please specify one from %s",
-			opts.ClusterType, supportedClusterTypes.List()))
-	}
+	// TODO (dixudx): uncomment to enable checking ClusterType
+	//if len(opts.ClusterType) > 0 && !supportedClusterTypes.Has(opts.ClusterType) {
+	//	allErrs = append(allErrs, fmt.Errorf("invalid cluster type %q, please specify one from %s",
+	//		opts.ClusterType, supportedClusterTypes.List()))
+	//}
 
 	if len(opts.ClusterNamePrefix) > ClusterNameMaxLength-DefaultRandomUIDLength-1 {
 		allErrs = append(allErrs, fmt.Errorf("cluster name prefix %s is longer than %d",
@@ -145,7 +144,7 @@ func (opts *ClusterRegistrationOptions) Validate() []error {
 	return allErrs
 }
 
-var supportedClusterTypes = sets.NewString(
-	string(clusterapi.EdgeClusterSelfProvisioned),
-	// todo: add more types
-)
+//var supportedClusterTypes = sets.NewString(
+//	string(clusterapi.EdgeCluster),
+//	// todo: add more types
+//)

--- a/pkg/apis/clusters/v1beta1/types.go
+++ b/pkg/apis/clusters/v1beta1/types.go
@@ -28,8 +28,8 @@ type ClusterType string
 
 // These are the valid values for ClusterType
 const (
-	// self provisioned edge cluster
-	EdgeClusterSelfProvisioned ClusterType = "EdgeClusterSelfProvisioned"
+	// edge cluster
+	EdgeCluster ClusterType = "EdgeCluster"
 
 	// todo: add more types
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
Currently there is only one kind of ClusterType, i.e., `EdgeCluster`. Commenting out checking cluster type to allow more customized cluster type.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #89 

#### Special notes for your reviewer:
