### PR TITLE
initializes description.raw to avoid index out of range

### DIFF
--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -601,6 +601,7 @@ func (deployer *Deployer) populateDescriptions(base *appsapi.Base) error {
 		desc.Name = fmt.Sprintf("%s-helm", base.Name)
 		desc.Spec.Deployer = appsapi.DescriptionHelmDeployer
 		desc.Spec.Charts = allChartRefs
+		desc.Spec.Raw = make([][]byte, len(allChartRefs))
 		err := deployer.syncDescriptions(base, desc)
 		if err != nil {
 			allErrs = append(allErrs, err)


### PR DESCRIPTION

#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
hub runs with this error, the reason is missing the initialization for helm description.raw
```
E0901 11:46:55.921602   91264 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
goroutine 467 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x6d85400, 0xc0007a89a0)
        /Users/hu/work/go/src/github.com/clusternet/clusternet/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x134
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /Users/hu/work/go/src/github.com/clusternet/clusternet/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0xdf
panic(0x6d85400, 0xc0007a89a0)
        /usr/local/go/src/runtime/panic.go:975 +0x4c6
github.com/clusternet/clusternet/pkg/hub/localizer.(*Localizer).ApplyOverridesToDescription(0xc00014f720, 0xc00072d500, 0x0, 0x0)
        /Users/hu/work/go/src/github.com/clusternet/clusternet/pkg/hub/localizer/localizer.go:188 +0x12f1

```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
