### PR TITLE
reuse app deployer credentials to collect cluster status when available

### DIFF
--- a/pkg/agent/deployer/constant.go
+++ b/pkg/agent/deployer/constant.go
@@ -22,6 +22,4 @@ const (
 	ServiceAccountNameKey = "service-account.name"
 	// ServiceAccountUIDKey is the key of the required annotation for SecretTypeServiceAccountToken secrets
 	ServiceAccountUIDKey = "service-account.uid"
-	// ClusternetAppSA is the service account where we store credentials to deploy resources
-	ClusternetAppSA = "clusternet-app-deployer"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
`StatusManager` reuses ServiceAccount `clusternet-app-deployer` when available to collect cluster status. If not, then it falls back to use legacy in-cluster `kubeClient`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #99

#### Special notes for your reviewer:
