### PR TITLE
filter out empty overrides before applying

### DIFF
--- a/pkg/hub/localizer/patch.go
+++ b/pkg/hub/localizer/patch.go
@@ -19,6 +19,7 @@ package localizer
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -38,6 +39,16 @@ func applyOverrides(original []byte, overrides []appsapi.OverrideConfig) ([]byte
 		overrideBytes, err := yaml.YAMLToJSON([]byte(overrideConfig.Value))
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert patch %s to JSON: %v", overrideConfig.Value, err)
+		}
+
+		// validation before apply override
+		if len(strings.TrimSpace(string(result))) == 0 {
+			result = overrideBytes
+			continue
+		}
+
+		if len(strings.TrimSpace(string(overrideBytes))) == 0 {
+			continue
 		}
 
 		switch overrideConfig.Type {

--- a/pkg/hub/localizer/patch_test.go
+++ b/pkg/hub/localizer/patch_test.go
@@ -67,6 +67,11 @@ hole: black
 			}`),
 			overrides: []appsapi.OverrideConfig{
 				{
+					Name:  "empty override",
+					Type:  appsapi.HelmType,
+					Value: ``,
+				},
+				{
 					Name:  "add/update value - json format",
 					Type:  appsapi.HelmType,
 					Value: `{"address":{"country":"US","state":"MA"},"boat":"fighter"}`,


### PR DESCRIPTION
#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
 Helm Override throw errors like this
```
E0902 11:21:58.228682    6177 base.go:275] Failed to apply overrides for Description clusternet-px5n9/app-demo-helm: failed to apply OverrideConfig overrideCommonLabels: unexpected end of JSON input
E0902 11:21:58.228713    6177 base.go:226] Failed to sync Description clusternet-px5n9/app-demo-helm: failed to apply OverrideConfig overrideCommonLabels: unexpected end of JSON input
E0902 11:21:58.230637    6177 base.go:278] error syncing 'clusternet-px5n9/app-demo': failed to apply OverrideConfig overrideCommonLabels: unexpected end of JSON input, requeuing
```

Should filter out empty override values before applying.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
