### PR TITLE
priority sort bugfix

### DIFF
--- a/pkg/hub/localizer/localizer.go
+++ b/pkg/hub/localizer/localizer.go
@@ -247,11 +247,11 @@ func (l *Localizer) getOverrides(namespace string, feed appsapi.Feed) ([]appsapi
 		return nil, err
 	}
 	sort.SliceStable(globs, func(i, j int) bool {
-		if globs[i].Spec.Priority < globs[j].Spec.Priority {
-			return true
+		if globs[i].Spec.Priority == globs[j].Spec.Priority {
+			return globs[i].CreationTimestamp.Second() < globs[j].CreationTimestamp.Second()
 		}
 
-		return globs[i].CreationTimestamp.Second() < globs[j].CreationTimestamp.Second()
+		return globs[i].Spec.Priority < globs[j].Spec.Priority
 	})
 
 	locs, err := l.locLister.Localizations(namespace).List(labels.SelectorFromSet(labels.Set{
@@ -261,11 +261,11 @@ func (l *Localizer) getOverrides(namespace string, feed appsapi.Feed) ([]appsapi
 		return nil, err
 	}
 	sort.SliceStable(locs, func(i, j int) bool {
-		if locs[i].Spec.Priority < locs[j].Spec.Priority {
-			return true
+		if locs[i].Spec.Priority == locs[j].Spec.Priority {
+			return locs[i].CreationTimestamp.Second() < locs[j].CreationTimestamp.Second()
 		}
 
-		return locs[i].CreationTimestamp.Second() < locs[j].CreationTimestamp.Second()
+		return locs[i].Spec.Priority < locs[j].Spec.Priority
 	})
 
 	var allOverrideConfigs []appsapi.OverrideConfig


### PR DESCRIPTION
#### What type of PR is this?
bugfix
#### What this PR does / why we need it:
consider this case: loc[i].priority > loc[j].priority and loc[i].creationTimestamp < loc[j].creationTimestamp
the sort result is not expected.

so i modify sort func to fix this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
