### PR TITLE
use a whitespace explicitly for helm overrides

### DIFF
--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -601,7 +601,6 @@ func (deployer *Deployer) populateDescriptions(base *appsapi.Base) error {
 		desc.Name = fmt.Sprintf("%s-helm", base.Name)
 		desc.Spec.Deployer = appsapi.DescriptionHelmDeployer
 		desc.Spec.Charts = allChartRefs
-		desc.Spec.Raw = make([][]byte, len(allChartRefs))
 		err := deployer.syncDescriptions(base, desc)
 		if err != nil {
 			allErrs = append(allErrs, err)

--- a/pkg/hub/localizer/localizer.go
+++ b/pkg/hub/localizer/localizer.go
@@ -168,6 +168,7 @@ func (l *Localizer) ApplyOverridesToDescription(desc *appsapi.Description) error
 	descCopy := desc.DeepCopy()
 	switch descCopy.Spec.Deployer {
 	case appsapi.DescriptionHelmDeployer:
+		desc.Spec.Raw = make([][]byte, len(descCopy.Spec.Charts))
 		for idx, chartRef := range descCopy.Spec.Charts {
 			overrides, err := l.getOverrides(descCopy.Namespace, appsapi.Feed{
 				Kind:       chartKind.Kind,
@@ -180,7 +181,8 @@ func (l *Localizer) ApplyOverridesToDescription(desc *appsapi.Description) error
 				continue
 			}
 
-			result, err := applyOverrides([]byte(""), overrides)
+			// use a whitespace explicitly
+			result, err := applyOverrides([]byte(" "), overrides)
 			if err != nil {
 				allErrs = append(allErrs, err)
 				continue

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -213,6 +213,9 @@ func GetOverrides(descLister applisters.DescriptionLister, hr *appsapi.HelmRelea
 			recorder.Event(desc, corev1.EventTypeWarning, "UnequalLengths", msg)
 			return nil, errors.New(msg)
 		}
+		if len(strings.TrimSpace(string(desc.Spec.Raw[index]))) == 0 {
+			return overrideValues, nil
+		}
 		err := json.Unmarshal(desc.Spec.Raw[index], &overrideValues)
 		return overrideValues, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
When a HelmChart gets no overrides, the override results will be empty.
> Description.apps.clusternet.io "app-demo-helm" is invalid: spec.raw: Invalid value: "": spec.raw in body must be of type byte: ""

And to make sure `spec.Raw` have the same lengths with `spec.Charts`, a whitespace is explicitly set by default.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
supercedes #97 

#### Special notes for your reviewer:
