### PR TITLE
fix invalid spec.replicas type during json patching

### DIFF
--- a/examples/applications/localization.yaml
+++ b/examples/applications/localization.yaml
@@ -57,7 +57,7 @@ spec:
         [
           {
             "path": "/spec/replicas",
-            "value": "3",
+            "value": 3,
             "op": "replace"
           },
           {
@@ -124,7 +124,7 @@ spec:
         [
           {
             "path": "/spec/replicas",
-            "value": "1",
+            "value": 1,
             "op": "replace"
           }
         ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/documentation

#### What this PR does / why we need it:
invalid field type

`spec.replicas` should be int instead of string.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes bugs introduced by #73 

#### Special notes for your reviewer:
