### PR TITLE
not wait for cache sync to support Kubernetes version skew

### DIFF
--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -164,7 +164,9 @@ func (hub *Hub) Run(ctx context.Context) error {
 			// waits for all started informers' cache got synced
 			hub.kubeInformerFactory.WaitForCacheSync(ctx.Done())
 			hub.clusternetInformerFactory.WaitForCacheSync(ctx.Done())
-			config.GenericConfig.SharedInformerFactory.WaitForCacheSync(ctx.Done())
+			// TODO: uncomment this when module "k8s.io/apiserver" gets bumped to a higher version.
+			// 		supports k8s.io/apiserver version skew
+			// config.GenericConfig.SharedInformerFactory.WaitForCacheSync(ctx.Done())
 
 			go func() {
 				hub.crrApprover.Run(DefaultThreadiness, context.StopCh)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
#132 waits for cache sync when starting clusternet controllers, which may be not compatible with older Kubernetes versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
xref #137 

#### Special notes for your reviewer:
