### PR TITLE
removing deprecated field ParentAPIServerURL

### DIFF
--- a/manifests/crds/clusters.clusternet.io_managedclusters.yaml
+++ b/manifests/crds/clusters.clusternet.io_managedclusters.yaml
@@ -188,9 +188,6 @@ spec:
                     format: int32
                     type: integer
                 type: object
-              parentAPIServerURL:
-                description: 'DEPRECATED: will be removed in future release. ParentAPIServerURL is the advertising url/address of managed Kubernetes cluster registering to'
-                type: string
               platform:
                 description: platform indicates the running platform of the cluster
                 type: string

--- a/pkg/agent/status_manager.go
+++ b/pkg/agent/status_manager.go
@@ -63,7 +63,7 @@ func NewStatusManager(ctx context.Context, apiserverURL string, regOpts *Cluster
 
 	return &Manager{
 		statusReportFrequency: regOpts.ClusterStatusReportFrequency,
-		clusterStatusController: clusterstatus.NewController(ctx, apiserverURL, regOpts.ParentURL,
+		clusterStatusController: clusterstatus.NewController(ctx, apiserverURL,
 			kubeClient, regOpts.ClusterStatusCollectFrequency, regOpts.ClusterStatusReportFrequency),
 	}
 }

--- a/pkg/apis/clusters/v1beta1/types.go
+++ b/pkg/apis/clusters/v1beta1/types.go
@@ -235,12 +235,6 @@ type ManagedClusterStatus struct {
 	// +optional
 	UseSocket bool `json:"useSocket,omitempty"`
 
-	// DEPRECATED: will be removed in future release.
-	// ParentAPIServerURL is the advertising url/address of managed Kubernetes cluster registering to
-	//
-	// +optional
-	ParentAPIServerURL string `json:"parentAPIServerURL,omitempty"`
-
 	// Allocatable is the sum of allocatable resources for nodes in the cluster
 	// +optional
 	Allocatable corev1.ResourceList `json:"allocatable,omitempty"`

--- a/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
+++ b/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
@@ -50,14 +50,13 @@ type Controller struct {
 	apiserverURL       string
 	appPusherEnabled   bool
 	useSocket          bool
-	parentAPIServer    string
 	nodeLister         corev1lister.NodeLister
 	nodeSynced         cache.InformerSynced
 	podLister          corev1lister.PodLister
 	podSynced          cache.InformerSynced
 }
 
-func NewController(ctx context.Context, apiserverURL, parentAPIServerURL string, kubeClient kubernetes.Interface, collectingPeriod metav1.Duration, heartbeatFrequency metav1.Duration) *Controller {
+func NewController(ctx context.Context, apiserverURL string, kubeClient kubernetes.Interface, collectingPeriod metav1.Duration, heartbeatFrequency metav1.Duration) *Controller {
 	kubeInformerFactory := informers.NewSharedInformerFactory(kubeClient, known.DefaultResync)
 	kubeInformerFactory.Core().V1().Nodes().Informer()
 	kubeInformerFactory.Core().V1().Pods().Informer()
@@ -71,7 +70,6 @@ func NewController(ctx context.Context, apiserverURL, parentAPIServerURL string,
 		apiserverURL:       apiserverURL,
 		appPusherEnabled:   utilfeature.DefaultFeatureGate.Enabled(features.AppPusher),
 		useSocket:          utilfeature.DefaultFeatureGate.Enabled(features.SocketConnection),
-		parentAPIServer:    parentAPIServerURL,
 		nodeLister:         kubeInformerFactory.Core().V1().Nodes().Lister(),
 		nodeSynced:         kubeInformerFactory.Core().V1().Nodes().Informer().HasSynced,
 		podLister:          kubeInformerFactory.Core().V1().Pods().Lister(),
@@ -126,7 +124,6 @@ func (c *Controller) collectingClusterStatus(ctx context.Context) {
 	status.Readyz = c.getHealthStatus(ctx, "/readyz")
 	status.AppPusher = c.appPusherEnabled
 	status.UseSocket = c.useSocket
-	status.ParentAPIServerURL = c.parentAPIServer
 	status.ClusterCIDR = clusterCIDR
 	status.ServiceCIDR = serviceCIDR
 	status.NodeStatistics = nodeStatistics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/apis
kind/change

#### What this PR does / why we need it:
xref #164 

This PR removes deprecated `ManagedCluster.Status.ParentAPIServerURL`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
