### PR TITLE
ignore metrics.k8s.io group to avoid same resource names with corev1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/controller-manager v0.21.2
 	k8s.io/klog/v2 v2.8.0
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
+	k8s.io/metrics v0.21.2
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1335,6 +1335,8 @@ k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iL
 k8s.io/kubectl v0.21.0 h1:WZXlnG/yjcE4LWO2g6ULjFxtzK6H1TKzsfaBFuVIhNg=
 k8s.io/kubectl v0.21.0/go.mod h1:EU37NukZRXn1TpAkMUoy8Z/B2u6wjHDS4aInsDzVvks=
 k8s.io/metrics v0.21.0/go.mod h1:L3Ji9EGPP1YBbfm9sPfEXSpnj8i24bfQbAFAsW0NueQ=
+k8s.io/metrics v0.21.2 h1:6ajprhWZnI64RSrNqET0cBdwzaxPxr9Vh8zURBkR1zY=
+k8s.io/metrics v0.21.2/go.mod h1:wzlOINZMCtWq8dR9gHlyaOemmYlOpAoldEIXE82gAhI=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/hub/apiserver/shadow/apiserver.go
+++ b/pkg/hub/apiserver/shadow/apiserver.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 
 	shadowinstall "github.com/clusternet/clusternet/pkg/apis/shadow/install"
 	shadowapi "github.com/clusternet/clusternet/pkg/apis/shadow/v1alpha1"
@@ -166,6 +167,13 @@ func (ss *ShadowAPIServer) InstallShadowAPIGroups(stopCh <-chan struct{}, cl dis
 
 		// skip shadow group to avoid getting nested
 		if apiGroupResource.Group.Name == shadowapi.GroupName {
+			continue
+		}
+
+		// ignore "metrics.k8s.io" group
+		// where PodMetrics uses pods as resource name, NodeMetrics uses nodes as resource name
+		// which conflicts with corev1.Pod and corev1.Node
+		if apiGroupResource.Group.Name == metricsapi.GroupName {
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:

```bash
$ kubectl api-resources | grep metrics.k8s.io
nodes    metrics.k8s.io/v1beta1    false    NodeMetrics
pods     metrics.k8s.io/v1beta1    true     PodMetrics
```

```bash
nodes    no    v1    false    Node
pods     po    v1    true     Pod
```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
