### PR TITLE
migrate codecov to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,10 @@ jobs:
       - name: Run tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        if: matrix.go-version == '1.15.x'
+        uses: codecov/codecov-action@v2
         with:
-          file: ./coverage.out
+          files: ${{ env.GOPATH }}/src/github.com/${{ github.repository }}/coverage.out
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/clusternet/clusternet)](https://goreportcard.com/report/github.com/clusternet/clusternet)
 ![build](https://github.com/clusternet/clusternet/actions/workflows/ci.yml/badge.svg)
 [![Version](https://img.shields.io/github/v/release/clusternet/clusternet)](https://github.com/clusternet/clusternet/releases)
+[![codecov](https://codecov.io/gh/clusternet/clusternet/branch/main/graph/badge.svg)](https://codecov.io/gh/clusternet/clusternet)
 
 ----
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

#### What this PR does / why we need it:
On February 1, 2022, codecov v1 will be fully sunset and no longer function

ref [codecov Deprecration of v1](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
xref #157

#### Special notes for your reviewer:
