### PR TITLE
fix cluster label parsing

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -419,6 +419,9 @@ func newClusterRegistrationRequest(clusterID types.UID, clusterType, clusterName
 }
 
 func parseClusterLabels(clusterLabels string) map[string]string {
+	if strings.TrimSpace(clusterLabels) == "" {
+		return nil
+	}
 	clusterLabelsMap := make(map[string]string)
 	clusterLabelsArray := strings.Split(clusterLabels, ",")
 	for _, labelString := range clusterLabelsArray {


### PR DESCRIPTION
Signed-off-by: silenceper <silenceper@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
When clusterlabel is empty, avoid print warning log: "invalid cluster label "
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
