### PR TITLE
no need to use JitterUntilWithContext

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -172,7 +172,7 @@ func (agent *Agent) registerSelfCluster(ctx context.Context) {
 	registerCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	wait.JitterUntilWithContext(registerCtx, func(ctx context.Context) {
+	wait.UntilWithContext(registerCtx, func(ctx context.Context) {
 		// get cluster unique id
 		if agent.ClusterID == nil {
 			klog.Infof("retrieving cluster id")
@@ -220,7 +220,7 @@ func (agent *Agent) registerSelfCluster(ctx context.Context) {
 
 		// Cancel the context on success
 		cancel()
-	}, known.DefaultRetryPeriod, 0.3, true)
+	}, known.DefaultRetryPeriod)
 }
 
 func (agent *Agent) getClusterID(ctx context.Context, childClientSet kubernetes.Interface) (types.UID, error) {


### PR DESCRIPTION
#### What this PR does / why we need it:
I think we can simply use `wait.UntilWithContext` instead of `wait.JitterUntilWithContext` with jitter factor. This enhance code's readability.
