### PR TITLE
reconciling Description when HelmChart got changed

### DIFF
--- a/pkg/agent/deployer/generic/generic.go
+++ b/pkg/agent/deployer/generic/generic.go
@@ -86,6 +86,7 @@ func NewDeployer(syncMode clusterapi.ClusterSyncMode, appPusherEnabled bool,
 	descController, err := description.NewController(clusternetClient,
 		clusternetInformerFactory.Apps().V1alpha1().Descriptions(),
 		clusternetInformerFactory.Apps().V1alpha1().HelmReleases(),
+		clusternetInformerFactory.Apps().V1alpha1().HelmCharts(),
 		deployer.recorder,
 		deployer.handleDescription)
 	if err != nil {

--- a/pkg/hub/deployer/generic/generic.go
+++ b/pkg/hub/deployer/generic/generic.go
@@ -78,6 +78,7 @@ func NewDeployer(apiserverURL string, clusternetClient *clusternetclientset.Clie
 	descController, err := description.NewController(clusternetClient,
 		clusternetInformerFactory.Apps().V1alpha1().Descriptions(),
 		clusternetInformerFactory.Apps().V1alpha1().HelmReleases(),
+		clusternetInformerFactory.Apps().V1alpha1().HelmCharts(),
 		deployer.recorder,
 		deployer.handleDescription)
 	if err != nil {

--- a/pkg/hub/deployer/helm/helm.go
+++ b/pkg/hub/deployer/helm/helm.go
@@ -122,6 +122,7 @@ func NewDeployer(apiserverURL string, clusternetClient *clusternetclientset.Clie
 	descController, err := description.NewController(clusternetClient,
 		clusternetInformerFactory.Apps().V1alpha1().Descriptions(),
 		clusternetInformerFactory.Apps().V1alpha1().HelmReleases(),
+		clusternetInformerFactory.Apps().V1alpha1().HelmCharts(),
 		deployer.recorder,
 		deployer.handleDescription)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
When a HelmChart got updated, all referred Descriptions should be reconciled to use newest updates.

```yaml
apiVersion: apps.clusternet.io/v1alpha1
kind: HelmChart
metadata:
  name: nginx
  namespace: kube-system
spec:
  chart: nginx
  repo: http://xxx.xxx.xxx.xxx
  targetNamespace: kube-system
  version: 0.2.0 --> update here from 0.1.0 to 0.2.0
```

All releated HelmRelease should be updated when updating HelmChart version from 0.1.0 to 0.2.0.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #200 

#### Special notes for your reviewer:
