### PR TITLE
supporting running clusternet-hub on k3s

### DIFF
--- a/cmd/clusternet-hub/app/app.go
+++ b/cmd/clusternet-hub/app/app.go
@@ -37,7 +37,10 @@ var (
 
 // NewClusternetHubCmd creates a *cobra.Command object with default parameters
 func NewClusternetHubCmd(ctx context.Context) *cobra.Command {
-	opts := options.NewHubServerOptions()
+	opts, err := options.NewHubServerOptions()
+	if err != nil {
+		klog.Fatalf("unable to initialize command options: %v", err)
+	}
 
 	cmd := &cobra.Command{
 		Use:  cmdName,
@@ -50,7 +53,7 @@ func NewClusternetHubCmd(ctx context.Context) *cobra.Command {
 			if err := opts.Complete(); err != nil {
 				klog.Exit(err)
 			}
-			if err := opts.Validate(args); err != nil {
+			if err := opts.Validate(); err != nil {
 				klog.Exit(err)
 			}
 
@@ -70,9 +73,8 @@ func NewClusternetHubCmd(ctx context.Context) *cobra.Command {
 		},
 	}
 
+	// bind flags
 	flags := cmd.Flags()
-	flags.BoolVar(&opts.TunnelLogging, "enable-tunnel-logging", opts.TunnelLogging, "Enable tunnel logging")
-
 	version.AddVersionFlag(flags)
 	opts.AddFlags(flags)
 	utilfeature.DefaultMutableFeatureGate.AddFlag(flags)

--- a/deploy/hub/clusternet_hub_deployment.yaml
+++ b/deploy/hub/clusternet_hub_deployment.yaml
@@ -63,8 +63,15 @@ spec:
         - name: clusternet-hub
           image: ghcr.io/clusternet/clusternet-hub:v0.6.0
           imagePullPolicy: IfNotPresent
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           command:
             - /usr/local/bin/clusternet-hub
             - --secure-port=443
             - --feature-gates=SocketConnection=true,Deployer=true,ShadowAPI=true,FeedInUseProtection=true
+            - --anonymous-auth-supported=true
+            - --leader-elect-resource-namespace=$(SYSTEM_NAMESPACE)
             - -v=4

--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -106,9 +106,10 @@ type Deployer struct {
 	apiserverURL string
 }
 
-func NewDeployer(apiserverURL string, kubeclient *kubernetes.Clientset, clusternetclient *clusternetclientset.Clientset,
+func NewDeployer(apiserverURL, systemNamespace string,
+	kubeclient *kubernetes.Clientset, clusternetclient *clusternetclientset.Clientset,
 	clusternetInformerFactory clusternetinformers.SharedInformerFactory, kubeInformerFactory kubeinformers.SharedInformerFactory,
-	recorder record.EventRecorder) (*Deployer, error) {
+	recorder record.EventRecorder, anonymousAuthSupported bool) (*Deployer, error) {
 	feedInUseProtection := utilfeature.DefaultFeatureGate.Enabled(features.FeedInUseProtection)
 
 	deployer := &Deployer{
@@ -140,15 +141,17 @@ func NewDeployer(apiserverURL string, kubeclient *kubernetes.Clientset, clustern
 	}
 	deployer.chartController = helmChartController
 
-	helmDeployer, err := helm.NewDeployer(apiserverURL, clusternetclient, kubeclient, clusternetInformerFactory,
-		kubeInformerFactory, deployer.recorder)
+	helmDeployer, err := helm.NewDeployer(apiserverURL, systemNamespace,
+		clusternetclient, kubeclient, clusternetInformerFactory,
+		kubeInformerFactory, deployer.recorder, anonymousAuthSupported)
 	if err != nil {
 		return nil, err
 	}
 	deployer.helmDeployer = helmDeployer
 
-	genericDeployer, err := generic.NewDeployer(apiserverURL, clusternetclient, clusternetInformerFactory,
-		kubeInformerFactory, deployer.recorder)
+	genericDeployer, err := generic.NewDeployer(apiserverURL, systemNamespace,
+		clusternetclient, clusternetInformerFactory, kubeInformerFactory,
+		deployer.recorder, anonymousAuthSupported)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/known/constant.go
+++ b/pkg/known/constant.go
@@ -38,6 +38,10 @@ const (
 
 	// ClusternetAppSA is the service account where we store credentials to deploy resources
 	ClusternetAppSA = "clusternet-app-deployer"
+
+	// ClusternetHubProxyServiceAccount is the service account that can be used for proxying requests to child clusters.
+	// This will be also used by deployer in clusternet-hub when flag "--anonymous-auth-supported" is set to false.
+	ClusternetHubProxyServiceAccount = "clusternet-hub-proxy"
 )
 
 // These are internal finalizer values to Clusternet, must be qualified name.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:

If feature gate `SocketConnection` is enabled when deploying `clusternet-agent`, currently `clusternet-hub` will use `system:anonymous` for authx by default when deploying applications to child clusters by deloyer from hub side. While this is not working when running `clusternet-hub` on k3s, since [k3s set `--anonymous-auth=false` explicitly](https://github.com/k3s-io/k3s/blob/f18b3252c0fbdfdc2a8e4d0a6d8deb4921052af9/pkg/daemons/control/server.go#L183-L185).

This PR introduced a new flag `anonymous-auth-supported` to indicate whether [anonymous auth](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-requests) was supported by underlying `kube-apiserver`.

If that was supported, the deployers in Clusternet will use `system:anonymous` for authx, otherwise, serviceaccount "`clusternet-hub-proxy`" will be used instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #201 

#### Special notes for your reviewer:
