### PR TITLE
configurable clusternet reserved namespace

### DIFF
--- a/pkg/apis/apps/v1alpha1/manifest.go
+++ b/pkg/apis/apps/v1alpha1/manifest.go
@@ -21,11 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	// objects will be store into Manifest with ReservedNamespace
-	ReservedNamespace = "clusternet-reserved"
-)
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope="Namespaced",categories=clusternet

--- a/pkg/controllers/apps/localization/localization.go
+++ b/pkg/controllers/apps/localization/localization.go
@@ -73,27 +73,31 @@ type Controller struct {
 	recorder record.EventRecorder
 
 	syncHandlerFunc SyncHandlerFunc
+
+	// namespace where Manifests are created
+	reservedNamespace string
 }
 
 func NewController(clusternetClient clusternetclientset.Interface,
 	locInformer appinformers.LocalizationInformer,
 	chartInformer appinformers.HelmChartInformer, manifestInformer appinformers.ManifestInformer,
-	recorder record.EventRecorder, syncHandlerFunc SyncHandlerFunc) (*Controller, error) {
+	recorder record.EventRecorder, syncHandlerFunc SyncHandlerFunc, reservedNamespace string) (*Controller, error) {
 	if syncHandlerFunc == nil {
 		return nil, fmt.Errorf("syncHandlerFunc must be set")
 	}
 
 	c := &Controller{
-		clusternetClient: clusternetClient,
-		workqueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "localization"),
-		locLister:        locInformer.Lister(),
-		locSynced:        locInformer.Informer().HasSynced,
-		chartLister:      chartInformer.Lister(),
-		chartSynced:      chartInformer.Informer().HasSynced,
-		manifestLister:   manifestInformer.Lister(),
-		manifestSynced:   manifestInformer.Informer().HasSynced,
-		recorder:         recorder,
-		syncHandlerFunc:  syncHandlerFunc,
+		clusternetClient:  clusternetClient,
+		workqueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "localization"),
+		locLister:         locInformer.Lister(),
+		locSynced:         locInformer.Informer().HasSynced,
+		chartLister:       chartInformer.Lister(),
+		chartSynced:       chartInformer.Informer().HasSynced,
+		manifestLister:    manifestInformer.Lister(),
+		manifestSynced:    manifestInformer.Informer().HasSynced,
+		recorder:          recorder,
+		syncHandlerFunc:   syncHandlerFunc,
+		reservedNamespace: reservedNamespace,
 	}
 
 	// Manage the addition/update of Localization
@@ -332,7 +336,7 @@ func (c *Controller) getLabelsForPatching(loc *appsapi.Localization) (map[string
 			labelsToPatch[string(chart.UID)] = &chartKind.Kind
 		}
 	default:
-		manifests, err := utils.ListManifestsBySelector(c.manifestLister, loc.Spec.Feed)
+		manifests, err := utils.ListManifestsBySelector(c.reservedNamespace, c.manifestLister, loc.Spec.Feed)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/apps/manifest/manifest.go
+++ b/pkg/controllers/apps/manifest/manifest.go
@@ -66,11 +66,15 @@ type Controller struct {
 
 	recorder        record.EventRecorder
 	syncHandlerFunc SyncHandlerFunc
+
+	// namespace where Manifests are created
+	reservedNamespace string
 }
 
 func NewController(clusternetClient clusternetclientset.Interface,
 	manifestInformer appinformers.ManifestInformer, baseInformer appinformers.BaseInformer,
-	feedInUseProtection bool, recorder record.EventRecorder, syncHandlerFunc SyncHandlerFunc) (*Controller, error) {
+	feedInUseProtection bool, recorder record.EventRecorder, syncHandlerFunc SyncHandlerFunc,
+	reservedNamespace string) (*Controller, error) {
 	if syncHandlerFunc == nil {
 		return nil, fmt.Errorf("syncHandlerFunc must be set")
 	}
@@ -85,6 +89,7 @@ func NewController(clusternetClient clusternetclientset.Interface,
 		feedInUseProtection: feedInUseProtection,
 		recorder:            recorder,
 		syncHandlerFunc:     syncHandlerFunc,
+		reservedNamespace:   reservedNamespace,
 	}
 
 	// Manage the addition/update of Manifest
@@ -193,7 +198,7 @@ func (c *Controller) updateBase(old, cur interface{}) {
 			continue
 		}
 
-		manifests, err := utils.ListManifestsBySelector(c.manifestLister, feed)
+		manifests, err := utils.ListManifestsBySelector(c.reservedNamespace, c.manifestLister, feed)
 		if err != nil {
 			klog.ErrorDepth(6, err)
 			continue

--- a/pkg/hub/apiserver/apiserver.go
+++ b/pkg/hub/apiserver/apiserver.go
@@ -117,7 +117,8 @@ func (cfg *Config) Complete() CompletedConfig {
 func (c completedConfig) New(tunnelLogging, socketConnection bool, extraHeaderPrefixes []string,
 	kubeclient *kubernetes.Clientset, clusternetclient *clusternet.Clientset,
 	clusternetInformerFactory informers.SharedInformerFactory,
-	clientBuilder clientbuilder.ControllerClientBuilder) (*HubAPIServer, error) {
+	clientBuilder clientbuilder.ControllerClientBuilder,
+	reservedNamespace string) (*HubAPIServer, error) {
 	genericServer, err := c.GenericConfig.New("clusternet-hub", genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err
@@ -162,7 +163,8 @@ func (c completedConfig) New(tunnelLogging, socketConnection bool, extraHeaderPr
 				kubeclient.RESTClient(),
 				clusternetclient,
 				clusternetInformerFactory.Apps().V1alpha1().Manifests().Lister(),
-				crdInformerFactory)
+				crdInformerFactory,
+				reservedNamespace)
 			crdInformerFactory.Start(context.StopCh)
 			return ss.InstallShadowAPIGroups(context.StopCh, kubeclient.DiscoveryClient)
 		}

--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -112,7 +112,7 @@ func NewHub(opts *options.HubServerOptions) (*Hub, error) {
 
 	var d *deployer.Deployer
 	if deployerEnabled {
-		d, err = deployer.NewDeployer(config.Host, opts.LeaderElection.ResourceNamespace,
+		d, err = deployer.NewDeployer(config.Host, opts.LeaderElection.ResourceNamespace, opts.ReservedNamespace,
 			kubeClient, clusternetClient, clusternetInformerFactory, kubeInformerFactory,
 			recorder, opts.AnonymousAuthSupported)
 		if err != nil {
@@ -154,7 +154,8 @@ func (hub *Hub) Run(ctx context.Context) error {
 		hub.kubeClient,
 		hub.clusternetClient,
 		hub.clusternetInformerFactory,
-		hub.clientBuilder)
+		hub.clientBuilder,
+		hub.options.ReservedNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/hub/options/options.go
+++ b/pkg/hub/options/options.go
@@ -64,6 +64,10 @@ type HubServerOptions struct {
 	// If not, serviceaccount "clusternet-hub-proxy" will be used instead.
 	AnonymousAuthSupported bool
 
+	// default namespace to create Manifest in
+	// default to be "clusternet-reserved"
+	ReservedNamespace string
+
 	RecommendedOptions *genericoptions.RecommendedOptions
 
 	LoopbackSharedInformerFactory informers.SharedInformerFactory
@@ -83,6 +87,7 @@ func NewHubServerOptions() (*HubServerOptions, error) {
 	return &HubServerOptions{
 		RecommendedOptions:     genericoptions.NewRecommendedOptions("fake", nil),
 		AnonymousAuthSupported: true,
+		ReservedNamespace:      known.ClusternetReservedNamespace,
 		ControllerOptions:      controllerOpts,
 	}, nil
 }
@@ -155,6 +160,7 @@ func (o *HubServerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&o.TunnelLogging, "enable-tunnel-logging", o.TunnelLogging, "Enable tunnel logging")
 	fs.BoolVar(&o.AnonymousAuthSupported, "anonymous-auth-supported", o.AnonymousAuthSupported, "Whether the anonymous access is allowed by the 'core' kubernetes server")
+	fs.StringVar(&o.ReservedNamespace, "reserved-namespace", o.ReservedNamespace, "The default namespace to create Manifest in")
 }
 
 func (o *HubServerOptions) addRecommendedOptionsFlags(fs *pflag.FlagSet) {

--- a/pkg/known/constant.go
+++ b/pkg/known/constant.go
@@ -36,6 +36,9 @@ const (
 	// This could be re-configured with flag "--leader-elect-resource-namespace"
 	ClusternetSystemNamespace = "clusternet-system"
 
+	// ClusternetReservedNamespace is the default namespace to store Manifest into
+	ClusternetReservedNamespace = "clusternet-reserved"
+
 	// ClusternetAppSA is the service account where we store credentials to deploy resources
 	ClusternetAppSA = "clusternet-app-deployer"
 

--- a/pkg/registry/shadow/template/transformer_test.go
+++ b/pkg/registry/shadow/template/transformer_test.go
@@ -49,7 +49,7 @@ func TestTransformManifest(t *testing.T) {
 						known.ConfigNameLabel:      "boo",
 						known.ConfigNamespaceLabel: "ns1",
 					},
-					Namespace:       appsapi.ReservedNamespace,
+					Namespace:       known.ClusternetReservedNamespace,
 					Name:            "bars-boo",
 					ResourceVersion: "1860247",
 					UID:             "13ff776c-1e91-4a84-b77d-6c35f3a52fed",

--- a/pkg/utils/feed.go
+++ b/pkg/utils/feed.go
@@ -63,7 +63,7 @@ func GetLabelsSelectorFromFeed(feed appsapi.Feed) (labels.Selector, error) {
 	return selector, nil
 }
 
-func ListManifestsBySelector(manifestLister applisters.ManifestLister, feed appsapi.Feed) ([]*appsapi.Manifest, error) {
+func ListManifestsBySelector(reservedNamespace string, manifestLister applisters.ManifestLister, feed appsapi.Feed) ([]*appsapi.Manifest, error) {
 	if manifestLister == nil {
 		return nil, errors.New("manifestLister is nil when listing charts by selector")
 	}
@@ -72,7 +72,7 @@ func ListManifestsBySelector(manifestLister applisters.ManifestLister, feed apps
 	if err != nil {
 		return nil, err
 	}
-	return manifestLister.Manifests(appsapi.ReservedNamespace).List(selector)
+	return manifestLister.Manifests(reservedNamespace).List(selector)
 }
 
 func FormatFeed(feed appsapi.Feed) string {


### PR DESCRIPTION
Signed-off-by: Di Xu <stephenhsu90@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/enhancement
kind/feature

#### What this PR does / why we need it:
This PR introduces a new flag `--reserved-namespace` to make reserved namespace `clusternet-reserved` configurable, which is the default namespace to create Manifest in.

With this PR, #209, #205, you could deploy `clusternet-hub` in any namespaces and using customized namespace to create Manifest objects.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
