### PR TITLE
migrating scheduling into scheduler framework with several plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/containerd/containerd v1.4.12 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/go-openapi/spec v0.19.5

--- a/manifests/crds/apps.clusternet.io_subscriptions.yaml
+++ b/manifests/crds/apps.clusternet.io_subscriptions.yaml
@@ -41,6 +41,29 @@ spec:
           spec:
             description: SubscriptionSpec defines the desired state of Subscription
             properties:
+              clusterTolerations:
+                description: ClusterTolerations tolerates any matched taints of ManagedCluster.
+                items:
+                  description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               feeds:
                 description: Feeds
                 items:
@@ -110,29 +133,6 @@ spec:
                           description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
-                    clusterTolerations:
-                      description: ClusterTolerations tolerates any matched taints of ManagedCluster.
-                      items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
                   required:
                   - clusterAffinity
                   type: object
@@ -150,12 +150,14 @@ spec:
                   type: string
                 type: array
               completedReleases:
-                description: Total number of completed releases targeted by this deployment.
-                format: int32
+                description: Total number of completed releases targeted by this Subscription.
                 type: integer
               desiredReleases:
                 description: Total number of Helm releases desired by this Subscription.
-                format: int32
+                type: integer
+              specHash:
+                description: SpecHash calculates the hash value of current SubscriptionSpec.
+                format: int64
                 type: integer
             type: object
         required:

--- a/pkg/apis/apps/v1alpha1/subscription.go
+++ b/pkg/apis/apps/v1alpha1/subscription.go
@@ -62,6 +62,11 @@ type SubscriptionSpec struct {
 	// +kubebuilder:validation:Required
 	Subscribers []Subscriber `json:"subscribers"`
 
+	// ClusterTolerations tolerates any matched taints of ManagedCluster.
+	//
+	// +optional
+	ClusterTolerations []corev1.Toleration `json:"clusterTolerations,omitempty"`
+
 	// Feeds
 	//
 	// +required
@@ -76,15 +81,20 @@ type SubscriptionStatus struct {
 	// +optional
 	BindingNamespaces []string `json:"bindingNamespaces,omitempty"`
 
+	// SpecHash calculates the hash value of current SubscriptionSpec.
+	//
+	// +optional
+	SpecHash uint64 `json:"specHash,omitempty"`
+
 	// Total number of Helm releases desired by this Subscription.
 	//
 	// +optional
-	DesiredReleases int32 `json:"desiredReleases,omitempty"`
+	DesiredReleases int `json:"desiredReleases,omitempty"`
 
-	// Total number of completed releases targeted by this deployment.
+	// Total number of completed releases targeted by this Subscription.
 	//
 	// +optional
-	CompletedReleases int32 `json:"completedReleases,omitempty"`
+	CompletedReleases int `json:"completedReleases,omitempty"`
 }
 
 // Subscriber defines
@@ -94,10 +104,6 @@ type Subscriber struct {
 	// +required
 	// +kubebuilder:validation:Required
 	ClusterAffinity *metav1.LabelSelector `json:"clusterAffinity"`
-
-	// ClusterTolerations tolerates any matched taints of ManagedCluster.
-	// +optional
-	ClusterTolerations []corev1.Toleration `json:"clusterTolerations,omitempty"`
 }
 
 // Feed defines the resource to be selected.

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -721,13 +721,6 @@ func (in *Subscriber) DeepCopyInto(out *Subscriber) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ClusterTolerations != nil {
-		in, out := &in.ClusterTolerations, &out.ClusterTolerations
-		*out = make([]corev1.Toleration, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
 	return
 }
 
@@ -808,6 +801,13 @@ func (in *SubscriptionSpec) DeepCopyInto(out *SubscriptionSpec) {
 	if in.Subscribers != nil {
 		in, out := &in.Subscribers, &out.Subscribers
 		*out = make([]Subscriber, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.ClusterTolerations != nil {
+		in, out := &in.ClusterTolerations, &out.ClusterTolerations
+		*out = make([]corev1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/scheduler/default_plugins.go
+++ b/pkg/scheduler/default_plugins.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	schedulerapis "github.com/clusternet/clusternet/pkg/scheduler/apis"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/names"
+)
+
+// getDefaultPlugins returns the default set of plugins.
+func getDefaultPlugins() *schedulerapis.Plugins {
+	return &schedulerapis.Plugins{
+		PreFilter: schedulerapis.PluginSet{},
+		Filter: schedulerapis.PluginSet{
+			Enabled: []schedulerapis.Plugin{
+				{Name: names.TaintToleration},
+			},
+		},
+		PostFilter: schedulerapis.PluginSet{},
+		PreScore:   schedulerapis.PluginSet{},
+		Score: schedulerapis.PluginSet{
+			Enabled: []schedulerapis.Plugin{
+				{Name: names.TaintToleration, Weight: 3},
+			},
+		},
+		Reserve: schedulerapis.PluginSet{},
+		Permit:  schedulerapis.PluginSet{},
+		PreBind: schedulerapis.PluginSet{},
+		Bind: schedulerapis.PluginSet{
+			Enabled: []schedulerapis.Plugin{
+				{Name: names.DefaultBinder},
+			},
+		},
+		PostBind: schedulerapis.PluginSet{},
+	}
+}

--- a/pkg/scheduler/framework/interfaces/interface.go
+++ b/pkg/scheduler/framework/interfaces/interface.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/informers"
-	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 
 	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
 	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
+	clusternet "github.com/clusternet/clusternet/pkg/generated/clientset/versioned"
+	informers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions"
 	schedulerapis "github.com/clusternet/clusternet/pkg/scheduler/apis"
 	"github.com/clusternet/clusternet/pkg/scheduler/parallelize"
 )
@@ -188,7 +188,7 @@ type ScoreExtensions interface {
 	// NormalizeScore is called for all cluster scores produced by the same plugin's "Score"
 	// method. A successful run of NormalizeScore will update the scores list and return
 	// a success status.
-	NormalizeScore(ctx context.Context, sub *appsapi.Subscription, scores ClusterScoreList) *Status
+	NormalizeScore(ctx context.Context, scores ClusterScoreList) *Status
 }
 
 // ScorePlugin is an interface that must be implemented by "Score" plugins to rank
@@ -201,7 +201,7 @@ type ScorePlugin interface {
 	// the subscription will be rejected.
 	Score(ctx context.Context, sub *appsapi.Subscription, namespacedCluster string) (int64, *Status)
 
-	// ScoreExtensions returns a ScoreExtensions interface if it implements one, or nil if does not.
+	// ScoreExtensions returns a ScoreExtensions interface if it implements one, or nil if not.
 	ScoreExtensions() ScoreExtensions
 }
 
@@ -363,10 +363,10 @@ type Handle interface {
 	// RejectWaitingSubscription rejects a waiting subscription given its UID.
 	RejectWaitingSubscription(uid types.UID)
 
-	// ClientSet returns a kubernetes clientSet.
-	ClientSet() clientset.Interface
+	// ClientSet returns a clusternet clientSet.
+	ClientSet() clusternet.Interface
 
-	// KubeConfig returns the raw kube schedulerapis.
+	// KubeConfig returns the raw kubeconfig.
 	KubeConfig() *restclient.Config
 
 	// EventRecorder returns an event recorder.

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultbinder
+
+import (
+	"context"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+
+	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	framework "github.com/clusternet/clusternet/pkg/scheduler/framework/interfaces"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/names"
+	"github.com/clusternet/clusternet/pkg/utils"
+)
+
+// DefaultBinder binds subscriptions to clusters using a clusternet client.
+type DefaultBinder struct {
+	handle framework.Handle
+}
+
+var _ framework.BindPlugin = &DefaultBinder{}
+
+// New creates a DefaultBinder.
+func New(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	return &DefaultBinder{handle: handle}, nil
+}
+
+// Name returns the name of the plugin.
+func (pl *DefaultBinder) Name() string {
+	return names.DefaultBinder
+}
+
+// Bind binds subscriptions to clusters using the clusternet client.
+func (pl *DefaultBinder) Bind(ctx context.Context, sub *appsapi.Subscription, namespacedClusters []string) *framework.Status {
+	klog.V(3).InfoS("Attempting to bind subscription to clusters",
+		"subscription", klog.KObj(sub), "clusters", namespacedClusters)
+
+	// use an ordered list
+	sort.SliceStable(namespacedClusters, func(i, j int) bool {
+		return namespacedClusters[i] < namespacedClusters[j]
+	})
+
+	subCopy := sub.DeepCopy()
+	subCopy.Status.BindingNamespaces = namespacedClusters
+	subCopy.Status.SpecHash = utils.HashSubscriptionSpec(&subCopy.Spec)
+	subCopy.Status.DesiredReleases = len(namespacedClusters)
+
+	_, err := pl.handle.ClientSet().AppsV1alpha1().Subscriptions(sub.Namespace).UpdateStatus(ctx, subCopy, metav1.UpdateOptions{})
+	if err != nil {
+		return framework.AsStatus(err)
+	}
+	return nil
+}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultbinder
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+
+	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	"github.com/clusternet/clusternet/pkg/generated/clientset/versioned/fake"
+	frameworkruntime "github.com/clusternet/clusternet/pkg/scheduler/framework/runtime"
+)
+
+func TestDefaultBinder(t *testing.T) {
+	testSubscription := &appsapi.Subscription{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns"},
+	}
+	testClusters := []string{
+		"cluster-ns-03",
+		"cluster-ns-01",
+	}
+	tests := []struct {
+		name           string
+		injectErr      error
+		wantedBindings []string
+	}{
+		{
+			name: "successful",
+			wantedBindings: []string{
+				"cluster-ns-01",
+				"cluster-ns-03",
+			},
+		}, {
+			name:      "binding error",
+			injectErr: errors.New("binding error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bindedNamespaces []string
+			client := fake.NewSimpleClientset(testSubscription)
+			client.PrependReactor("update", "subscriptions", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() != "status" {
+					return false, nil, nil
+				}
+				if tt.injectErr != nil {
+					return true, nil, tt.injectErr
+				}
+
+				bindedSubscription := action.(clienttesting.UpdateAction).GetObject().(*appsapi.Subscription)
+				if bindedSubscription != nil {
+					bindedNamespaces = bindedSubscription.Status.BindingNamespaces
+				}
+				return true, bindedSubscription, nil
+			})
+
+			fh, err := frameworkruntime.NewFramework(nil, nil, frameworkruntime.WithClientSet(client))
+			if err != nil {
+				t.Fatal(err)
+			}
+			binder := &DefaultBinder{handle: fh}
+			status := binder.Bind(context.Background(), testSubscription, testClusters)
+			if got := status.AsError(); (tt.injectErr != nil) != (got != nil) {
+				t.Errorf("got error %q, want %q", got, tt.injectErr)
+			}
+			if diff := cmp.Diff(tt.wantedBindings, bindedNamespaces); diff != "" {
+				t.Errorf("got different binding (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/plugins/helper/normalize_score.go
+++ b/pkg/scheduler/framework/plugins/helper/normalize_score.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file was copied from k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper/normalize_score.go and modified
+
+package helper
+
+import (
+	framework "github.com/clusternet/clusternet/pkg/scheduler/framework/interfaces"
+)
+
+// DefaultNormalizeScore generates a Normalize Score function that can normalize the
+// scores to [0, maxPriority]. If reverse is set to true, it reverses the scores by
+// subtracting it from maxPriority.
+func DefaultNormalizeScore(maxPriority int64, reverse bool, scores framework.ClusterScoreList) *framework.Status {
+	var maxCount int64
+	for i := range scores {
+		if scores[i].Score > maxCount {
+			maxCount = scores[i].Score
+		}
+	}
+
+	if maxCount == 0 {
+		if reverse {
+			for i := range scores {
+				scores[i].Score = maxPriority
+			}
+		}
+		return nil
+	}
+
+	for i := range scores {
+		score := scores[i].Score
+
+		score = maxPriority * score / maxCount
+		if reverse {
+			score = maxPriority - score
+		}
+
+		scores[i].Score = score
+	}
+	return nil
+}

--- a/pkg/scheduler/framework/plugins/helper/normalize_score_test.go
+++ b/pkg/scheduler/framework/plugins/helper/normalize_score_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	framework "github.com/clusternet/clusternet/pkg/scheduler/framework/interfaces"
+)
+
+func TestDefaultNormalizeScore(t *testing.T) {
+	tests := []struct {
+		reverse        bool
+		scores         []int64
+		expectedScores []int64
+	}{
+		{
+			scores:         []int64{1, 2, 3, 4},
+			expectedScores: []int64{25, 50, 75, 100},
+		},
+		{
+			reverse:        true,
+			scores:         []int64{1, 2, 3, 4},
+			expectedScores: []int64{75, 50, 25, 0},
+		},
+		{
+			scores:         []int64{1000, 10, 20, 30},
+			expectedScores: []int64{100, 1, 2, 3},
+		},
+		{
+			reverse:        true,
+			scores:         []int64{1000, 10, 20, 30},
+			expectedScores: []int64{0, 99, 98, 97},
+		},
+		{
+			scores:         []int64{1, 1, 1, 1},
+			expectedScores: []int64{100, 100, 100, 100},
+		},
+		{
+			scores:         []int64{1000, 1, 1, 1},
+			expectedScores: []int64{100, 0, 0, 0},
+		},
+		{
+			reverse:        true,
+			scores:         []int64{0, 1, 1, 1},
+			expectedScores: []int64{100, 0, 0, 0},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
+			scores := framework.ClusterScoreList{}
+			for _, score := range test.scores {
+				scores = append(scores, framework.ClusterScore{Score: score})
+			}
+
+			expectedScores := framework.ClusterScoreList{}
+			for _, score := range test.expectedScores {
+				expectedScores = append(expectedScores, framework.ClusterScore{Score: score})
+			}
+
+			DefaultNormalizeScore(framework.MaxClusterScore, test.reverse, scores)
+			if diff := cmp.Diff(expectedScores, scores); diff != "" {
+				t.Errorf("Unexpected scores (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/plugins/names/names.go
+++ b/pkg/scheduler/framework/plugins/names/names.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+const (
+	DefaultBinder = "DefaultBinder"
+
+	TaintToleration = "TaintToleration"
+)

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -17,11 +17,16 @@ limitations under the License.
 package plugins
 
 import (
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/defaultbinder"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/names"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/tainttoleration"
 	"github.com/clusternet/clusternet/pkg/scheduler/framework/runtime"
 )
 
 // NewInTreeRegistry builds the registry with all the in-tree plugins.
 func NewInTreeRegistry() runtime.Registry {
-	// TODO: register plugins
-	return runtime.Registry{}
+	return runtime.Registry{
+		names.DefaultBinder:   defaultbinder.New,
+		names.TaintToleration: tainttoleration.New,
+	}
 }

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tainttoleration
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	v1helper "k8s.io/component-helpers/scheduling/corev1"
+
+	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
+	framework "github.com/clusternet/clusternet/pkg/scheduler/framework/interfaces"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/helper"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/plugins/names"
+)
+
+// TaintToleration is a plugin that checks if a subscription tolerates a cluster's taints.
+type TaintToleration struct {
+	handle framework.Handle
+}
+
+var _ framework.FilterPlugin = &TaintToleration{}
+var _ framework.ScorePlugin = &TaintToleration{}
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *TaintToleration) Name() string {
+	return names.TaintToleration
+}
+
+// Filter invoked at the filter extension point.
+func (pl *TaintToleration) Filter(ctx context.Context, sub *appsapi.Subscription, cluster *clusterapi.ManagedCluster) *framework.Status {
+	if cluster == nil {
+		return framework.AsStatus(fmt.Errorf("invalid cluster"))
+	}
+
+	filterPredicate := func(t *v1.Taint) bool {
+		// only interested in NoSchedule and NoExecute taints.
+		return t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute
+	}
+
+	taint, isUntolerated := v1helper.FindMatchingUntoleratedTaint(cluster.Spec.Taints, sub.Spec.ClusterTolerations, filterPredicate)
+	if !isUntolerated {
+		return nil
+	}
+
+	errReason := fmt.Sprintf("clusters(s) had taint {%s: %s}, that the subscription didn't tolerate",
+		taint.Key, taint.Value)
+	return framework.NewStatus(framework.UnschedulableAndUnresolvable, errReason)
+}
+
+// getAllTolerationEffectPreferNoSchedule gets the list of all Tolerations with Effect PreferNoSchedule or with no effect.
+// copied from k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+func getAllTolerationPreferNoSchedule(tolerations []v1.Toleration) (tolerationList []v1.Toleration) {
+	for _, toleration := range tolerations {
+		// Empty effect means all effects which includes PreferNoSchedule, so we need to collect it as well.
+		if len(toleration.Effect) == 0 || toleration.Effect == v1.TaintEffectPreferNoSchedule {
+			tolerationList = append(tolerationList, toleration)
+		}
+	}
+	return
+}
+
+// CountIntolerableTaintsPreferNoSchedule gives the count of intolerable taints of a subscription with effect PreferNoSchedule
+// copied from k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+func countIntolerableTaintsPreferNoSchedule(taints []v1.Taint, tolerations []v1.Toleration) (intolerableTaints int) {
+	for _, taint := range taints {
+		// check only on taints that have effect PreferNoSchedule
+		if taint.Effect != v1.TaintEffectPreferNoSchedule {
+			continue
+		}
+
+		if !v1helper.TolerationsTolerateTaint(tolerations, &taint) {
+			intolerableTaints++
+		}
+	}
+	return
+}
+
+// Score invoked at the Score extension point.
+func (pl *TaintToleration) Score(ctx context.Context, sub *appsapi.Subscription, namespacedCluster string) (int64, *framework.Status) {
+	// Convert the namespace/name string into a distinct namespace and name
+	ns, name, err := cache.SplitMetaNamespaceKey(namespacedCluster)
+	if err != nil {
+		return 0, framework.AsStatus(fmt.Errorf("invalid resource key: %s", namespacedCluster))
+	}
+
+	cluster, err := pl.handle.SharedInformerFactory().Clusters().V1beta1().ManagedClusters().Lister().ManagedClusters(ns).Get(name)
+	if err != nil {
+		return 0, framework.AsStatus(fmt.Errorf("getting cluster %s: %v", namespacedCluster, err))
+	}
+
+	score := int64(countIntolerableTaintsPreferNoSchedule(cluster.Spec.Taints,
+		getAllTolerationPreferNoSchedule(sub.Spec.ClusterTolerations)))
+	return score, nil
+}
+
+// NormalizeScore invoked after scoring all clusters.
+func (pl *TaintToleration) NormalizeScore(ctx context.Context, scores framework.ClusterScoreList) *framework.Status {
+	return helper.DefaultNormalizeScore(framework.MaxClusterScore, true, scores)
+}
+
+// ScoreExtensions of the Score plugin.
+func (pl *TaintToleration) ScoreExtensions() framework.ScoreExtensions {
+	return pl
+}
+
+// New initializes a new plugin and returns it.
+func New(_ runtime.Object, h framework.Handle) (framework.Plugin, error) {
+	return &TaintToleration{handle: h}, nil
+}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tainttoleration
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
+	"github.com/clusternet/clusternet/pkg/generated/clientset/versioned/fake"
+	informers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions"
+	framework "github.com/clusternet/clusternet/pkg/scheduler/framework/interfaces"
+	"github.com/clusternet/clusternet/pkg/scheduler/framework/runtime"
+)
+
+func clusterWithTaints(clusterNamespace string, taints []v1.Taint) *clusterapi.ManagedCluster {
+	return &clusterapi.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-test",
+			Namespace: clusterNamespace,
+		},
+		Spec: clusterapi.ManagedClusterSpec{
+			Taints: taints,
+		},
+	}
+}
+
+func subscriptionWithTolerations(subName string, tolerations []v1.Toleration) *appsapi.Subscription {
+	return &appsapi.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      subName,
+			Namespace: "default",
+		},
+		Spec: appsapi.SubscriptionSpec{
+			Subscribers: []appsapi.Subscriber{
+				{
+					ClusterAffinity: &metav1.LabelSelector{MatchLabels: map[string]string{}},
+				},
+			},
+			ClusterTolerations: tolerations,
+		},
+	}
+}
+
+func TestTaintTolerationScore(t *testing.T) {
+	tests := []struct {
+		name         string
+		subscription *appsapi.Subscription
+		clusters     []*clusterapi.ManagedCluster
+		expectedList framework.ClusterScoreList
+	}{
+		// basic test case
+		{
+			name: "cluster with taints tolerated by the subscription, gets a higher score than those cluster with intolerable taints",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{
+				Key:      "foo",
+				Operator: v1.TolerationOpEqual,
+				Value:    "bar",
+				Effect:   v1.TaintEffectPreferNoSchedule,
+			}}),
+			clusters: []*clusterapi.ManagedCluster{
+				clusterWithTaints("cluster-ns-01", []v1.Taint{{
+					Key:    "foo",
+					Value:  "bar",
+					Effect: v1.TaintEffectPreferNoSchedule,
+				}}),
+				clusterWithTaints("cluster-ns-02", []v1.Taint{{
+					Key:    "foo",
+					Value:  "blah",
+					Effect: v1.TaintEffectPreferNoSchedule,
+				}}),
+			},
+			expectedList: []framework.ClusterScore{
+				{NamespacedName: "cluster-ns-01/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-02/cluster-test", Score: 0},
+			},
+		},
+		// the count of taints that are tolerated by subscription, does not matter.
+		{
+			name: "the clusters that all of their taints are tolerated by the subscription, get the same score, no matter how many tolerable taints a cluster has",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{
+				{
+					Key:      "cpu-type",
+					Operator: v1.TolerationOpEqual,
+					Value:    "arm64",
+					Effect:   v1.TaintEffectPreferNoSchedule,
+				}, {
+					Key:      "disk-type",
+					Operator: v1.TolerationOpEqual,
+					Value:    "ssd",
+					Effect:   v1.TaintEffectPreferNoSchedule,
+				},
+			}),
+			clusters: []*clusterapi.ManagedCluster{
+				clusterWithTaints("cluster-ns-01", []v1.Taint{}),
+				clusterWithTaints("cluster-ns-02", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				}),
+				clusterWithTaints("cluster-ns-03", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					}, {
+						Key:    "disk-type",
+						Value:  "ssd",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				}),
+			},
+			expectedList: []framework.ClusterScore{
+				{NamespacedName: "cluster-ns-01/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-02/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-03/cluster-test", Score: framework.MaxClusterScore},
+			},
+		},
+		// the count of taints on a cluster that are not tolerated by subscription, matters.
+		{
+			name: "the more intolerable taints a cluster has, the lower score it gets.",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{
+				Key:      "foo",
+				Operator: v1.TolerationOpEqual,
+				Value:    "bar",
+				Effect:   v1.TaintEffectPreferNoSchedule,
+			}}),
+			clusters: []*clusterapi.ManagedCluster{
+				clusterWithTaints("cluster-ns-01", []v1.Taint{}),
+				clusterWithTaints("cluster-ns-02", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				}),
+				clusterWithTaints("cluster-ns-03", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					}, {
+						Key:    "disk-type",
+						Value:  "ssd",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				}),
+			},
+			expectedList: []framework.ClusterScore{
+				{NamespacedName: "cluster-ns-01/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-02/cluster-test", Score: 50},
+				{NamespacedName: "cluster-ns-03/cluster-test", Score: 0},
+			},
+		},
+		// taints-tolerations priority only takes care about the taints and tolerations that have effect PreferNoSchedule
+		{
+			name: "only taints and tolerations that have effect PreferNoSchedule are checked by taints-tolerations priority function",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{
+				{
+					Key:      "cpu-type",
+					Operator: v1.TolerationOpEqual,
+					Value:    "arm64",
+					Effect:   v1.TaintEffectNoSchedule,
+				}, {
+					Key:      "disk-type",
+					Operator: v1.TolerationOpEqual,
+					Value:    "ssd",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			}),
+			clusters: []*clusterapi.ManagedCluster{
+				clusterWithTaints("cluster-ns-01", []v1.Taint{}),
+				clusterWithTaints("cluster-ns-02", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectNoSchedule,
+					},
+				}),
+				clusterWithTaints("cluster-ns-03", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					}, {
+						Key:    "disk-type",
+						Value:  "ssd",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				}),
+			},
+			expectedList: []framework.ClusterScore{
+				{NamespacedName: "cluster-ns-01/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-02/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-03/cluster-test", Score: 0},
+			},
+		},
+		{
+			name: "Default behaviour No taints and tolerations, lands on cluster with no taints",
+			// subscription without tolerations
+			subscription: subscriptionWithTolerations("sub2", []v1.Toleration{}),
+			clusters: []*clusterapi.ManagedCluster{
+				// Cluster without taints
+				clusterWithTaints("cluster-ns-01", []v1.Taint{}),
+				clusterWithTaints("cluster-ns-02", []v1.Taint{
+					{
+						Key:    "cpu-type",
+						Value:  "arm64",
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				}),
+			},
+			expectedList: []framework.ClusterScore{
+				{NamespacedName: "cluster-ns-01/cluster-test", Score: framework.MaxClusterScore},
+				{NamespacedName: "cluster-ns-02/cluster-test", Score: 0},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, 0*time.Second)
+			for _, cls := range test.clusters {
+				if err := fakeInformerFactory.Clusters().V1beta1().ManagedClusters().Informer().GetStore().Add(cls); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			fh, err := runtime.NewFramework(nil, nil, runtime.WithInformerFactory(fakeInformerFactory))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p, _ := New(nil, fh)
+			var gotList framework.ClusterScoreList
+			for _, n := range test.clusters {
+				score, status := p.(framework.ScorePlugin).Score(context.Background(), test.subscription, klog.KObj(n).String())
+				if !status.IsSuccess() {
+					t.Errorf("unexpected error: %v", status)
+				}
+				gotList = append(gotList, framework.ClusterScore{NamespacedName: klog.KObj(n).String(), Score: score})
+			}
+
+			status := p.(framework.ScorePlugin).ScoreExtensions().NormalizeScore(context.Background(), gotList)
+			if !status.IsSuccess() {
+				t.Errorf("unexpected error: %v", status)
+			}
+
+			if !reflect.DeepEqual(test.expectedList, gotList) {
+				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			}
+		})
+	}
+}
+
+func TestTaintTolerationFilter(t *testing.T) {
+	tests := []struct {
+		name         string
+		subscription *appsapi.Subscription
+		cluster      *clusterapi.ManagedCluster
+		wantStatus   *framework.Status
+	}{
+		{
+			name:         "A subscription having no tolerations can't be scheduled onto a cluster with nonempty taints",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+				"clusters(s) had taint {dedicated: user1}, that the subscription didn't tolerate"),
+		},
+		{
+			name:         "A subscription which can be scheduled on a dedicated cluster assigned to user1 with effect NoSchedule",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
+		},
+		{
+			name:         "A subscription which can't be scheduled on a dedicated cluster assigned to user2 with effect NoSchedule",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{Key: "dedicated", Operator: "Equal", Value: "user2", Effect: "NoSchedule"}}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "NoSchedule"}}),
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+				"clusters(s) had taint {dedicated: user1}, that the subscription didn't tolerate"),
+		},
+		{
+			name:         "A subscription can be scheduled onto the cluster, with a toleration uses operator Exists that tolerates the taints on the cluster",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{Key: "foo", Operator: "Exists", Effect: "NoSchedule"}}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "foo", Value: "bar", Effect: "NoSchedule"}}),
+		},
+		{
+			name: "A subscription has multiple tolerations, cluster has multiple taints, all the taints are tolerated, subscription can be scheduled onto the cluster",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{
+				{Key: "dedicated", Operator: "Equal", Value: "user2", Effect: "NoSchedule"},
+				{Key: "foo", Operator: "Exists", Effect: "NoSchedule"},
+			}),
+			cluster: clusterWithTaints("clusterA", []v1.Taint{
+				{Key: "dedicated", Value: "user2", Effect: "NoSchedule"},
+				{Key: "foo", Value: "bar", Effect: "NoSchedule"},
+			}),
+		},
+		{
+			name: "A subscription has a toleration that keys and values match the taint on the cluster, but (non-empty) effect doesn't match, " +
+				"can't be scheduled onto the cluster",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "PreferNoSchedule"}}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "foo", Value: "bar", Effect: "NoSchedule"}}),
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
+				"clusters(s) had taint {foo: bar}, that the subscription didn't tolerate"),
+		},
+		{
+			name: "The subscription has a toleration that keys and values match the taint on the cluster, the effect of toleration is empty, " +
+				"and the effect of taint is NoSchedule. Subscription can be scheduled onto the cluster",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar"}}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "foo", Value: "bar", Effect: "NoSchedule"}}),
+		},
+		{
+			name: "The subscription has a toleration that key and value don't match the taint on the cluster, " +
+				"but the effect of taint on cluster is PreferNoSchedule. Subscription can be scheduled onto the cluster",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{{Key: "dedicated", Operator: "Equal", Value: "user2", Effect: "NoSchedule"}}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "PreferNoSchedule"}}),
+		},
+		{
+			name: "The subscription has no toleration, " +
+				"but the effect of taint on cluster is PreferNoSchedule. Subscription can be scheduled onto the cluster",
+			subscription: subscriptionWithTolerations("sub1", []v1.Toleration{}),
+			cluster:      clusterWithTaints("clusterA", []v1.Taint{{Key: "dedicated", Value: "user1", Effect: "PreferNoSchedule"}}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p, _ := New(nil, nil)
+			gotStatus := p.(framework.FilterPlugin).Filter(context.Background(), test.subscription, test.cluster)
+			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
+				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -19,10 +19,14 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -81,6 +85,9 @@ type Scheduler struct {
 	SchedulingQueue workqueue.RateLimitingInterface
 
 	framework framework.Framework
+
+	lock           sync.RWMutex
+	subscribersMap map[string][]appsapi.Subscriber
 }
 
 // NewScheduler returns a new Scheduler.
@@ -121,6 +128,7 @@ func NewScheduler(schedulerOptions *options.SchedulerOptions) (*Scheduler, error
 		registry:                  plugins.NewInTreeRegistry(),
 		scheduleAlgorithm:         algorithm.NewGenericScheduler(schedulerCache),
 		SchedulingQueue:           workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		subscribersMap:            make(map[string][]appsapi.Subscriber),
 	}
 
 	framework, err := frameworkruntime.NewFramework(sched.registry,
@@ -134,7 +142,7 @@ func NewScheduler(schedulerOptions *options.SchedulerOptions) (*Scheduler, error
 	// register all metrics
 	metrics.Register()
 
-	addAllEventHandlers(sched)
+	sched.addAllEventHandlers()
 	return sched, nil
 }
 
@@ -352,13 +360,16 @@ func (sched *Scheduler) recordSchedulingFailure(sub *appsapi.Subscription, err e
 
 // addAllEventHandlers is a helper function used in tests and in Scheduler
 // to add event handlers for various informers.
-func addAllEventHandlers(sched *Scheduler) {
+func (sched *Scheduler) addAllEventHandlers() {
 	sched.ClusternetInformerFactory.Apps().V1alpha1().Subscriptions().Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			switch t := obj.(type) {
 			case *appsapi.Subscription:
 				sub := obj.(*appsapi.Subscription)
 				if sub.DeletionTimestamp != nil {
+					sched.lock.Lock()
+					defer sched.lock.Unlock()
+					delete(sched.subscribersMap, klog.KObj(sub).String())
 					return false
 				}
 
@@ -377,17 +388,80 @@ func addAllEventHandlers(sched *Scheduler) {
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				// TODO
 				sub := obj.(*appsapi.Subscription)
+				sched.lock.Lock()
+				defer sched.lock.Unlock()
+				sched.subscribersMap[klog.KObj(sub).String()] = sub.Spec.Subscribers
 				sched.SchedulingQueue.AddRateLimited(klog.KObj(sub).String())
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				// TODO
+				oldSub := oldObj.(*appsapi.Subscription)
 				newSub := newObj.(*appsapi.Subscription)
+
+				// Decide whether discovery has reported a spec change.
+				if reflect.DeepEqual(oldSub.Spec, newSub.Spec) {
+					klog.V(4).Infof("no updates on the spec of Subscription %s, skipping syncing", klog.KObj(oldSub))
+					return
+				}
+
+				sched.lock.Lock()
+				defer sched.lock.Unlock()
+				sched.subscribersMap[klog.KObj(newSub).String()] = newSub.Spec.Subscribers
 				sched.SchedulingQueue.AddRateLimited(klog.KObj(newSub).String())
 			},
 		},
 	})
+
+	enqueueSubscriptionForClusterFunc := func(mcls *clusterapi.ManagedCluster) {
+		sched.lock.RLock()
+		defer sched.lock.RUnlock()
+
+		for key, subscribers := range sched.subscribersMap {
+			for _, subscriber := range subscribers {
+				selector, err := metav1.LabelSelectorAsSelector(subscriber.ClusterAffinity)
+				if err != nil {
+					klog.ErrorDepth(5, fmt.Sprintf("failed to parse labelSelector in Subscription %s: %v", key, err))
+					continue
+				}
+				if !selector.Matches(labels.Set(mcls.Labels)) {
+					continue
+				}
+				sched.SchedulingQueue.AddRateLimited(key)
+				break
+			}
+		}
+	}
+
+	sched.ClusternetInformerFactory.Clusters().V1beta1().ManagedClusters().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			mcls := obj.(*clusterapi.ManagedCluster)
+			if mcls.DeletionTimestamp != nil {
+				return
+			}
+			enqueueSubscriptionForClusterFunc(mcls)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldMcls := oldObj.(*clusterapi.ManagedCluster)
+			newMcls := newObj.(*clusterapi.ManagedCluster)
+
+			if newMcls.DeletionTimestamp != nil {
+				return
+			}
+
+			// no updates on the labels/taints of ManagedCluster
+			if reflect.DeepEqual(oldMcls.Labels, newMcls.Labels) && reflect.DeepEqual(oldMcls.Spec.Taints, newMcls.Spec.Taints) {
+				klog.V(4).Infof("no updates on the labels/taints of ManagedCluster %s, skipping syncing", klog.KObj(oldMcls))
+				return
+			}
+			enqueueSubscriptionForClusterFunc(newMcls)
+		},
+		DeleteFunc: func(obj interface{}) {
+			// when a ManagedCluster is deleted,
+			// - Auto populated objects, like Base and Description, will be auto-deleted on next sync/resync of subscribed Subscriptions
+			// - If current dedicated namespace is deleted, then all objects in this namespaces will be pruned.
+		},
+	})
+
 }
 
 // truncateMessage truncates a message if it hits the NoteLengthLimit.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -52,6 +52,7 @@ import (
 	frameworkruntime "github.com/clusternet/clusternet/pkg/scheduler/framework/runtime"
 	"github.com/clusternet/clusternet/pkg/scheduler/metrics"
 	"github.com/clusternet/clusternet/pkg/scheduler/options"
+	"github.com/clusternet/clusternet/pkg/scheduler/parallelize"
 	"github.com/clusternet/clusternet/pkg/utils"
 )
 
@@ -131,8 +132,13 @@ func NewScheduler(schedulerOptions *options.SchedulerOptions) (*Scheduler, error
 		subscribersMap:            make(map[string][]appsapi.Subscriber),
 	}
 
-	framework, err := frameworkruntime.NewFramework(sched.registry,
+	framework, err := frameworkruntime.NewFramework(sched.registry, getDefaultPlugins(),
 		frameworkruntime.WithEventRecorder(recorder),
+		frameworkruntime.WithInformerFactory(clusternetInformerFactory),
+		frameworkruntime.WithClientSet(clusternetClient),
+		frameworkruntime.WithKubeConfig(clientConfig),
+		frameworkruntime.WithParallelism(parallelize.DefaultParallelism),
+		frameworkruntime.WithRunAllFilters(false),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
-	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 
 	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
@@ -679,24 +678,4 @@ func ResourceNeedResync(original pkgruntime.Object, current pkgruntime.Object) b
 	}
 
 	return false
-}
-
-// FilterClustersByTolerations filters clusters that match the specified tolerations.
-func FilterClustersByTolerations(clusters []*clusterapi.ManagedCluster, tolerations []corev1.Toleration) []*clusterapi.ManagedCluster {
-	var res []*clusterapi.ManagedCluster
-	for _, cluster := range clusters {
-		if !IsClusterUntolerated(cluster, tolerations) {
-			res = append(res, cluster)
-		}
-	}
-	return res
-}
-
-// IsClusterUntolerated checks if the cluster does not match the specified tolerations.
-func IsClusterUntolerated(cluster *clusterapi.ManagedCluster, tolerations []corev1.Toleration) bool {
-	filterPredicate := func(t *corev1.Taint) bool {
-		return t.Effect == corev1.TaintEffectNoSchedule
-	}
-	_, isUntolerated := v1helper.FindMatchingUntoleratedTaint(cluster.Spec.Taints, tolerations, filterPredicate)
-	return isUntolerated
 }

--- a/pkg/utils/feed.go
+++ b/pkg/utils/feed.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 
+	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -158,4 +160,17 @@ func HasFeed(feed appsapi.Feed, feeds []appsapi.Feed) bool {
 	}
 
 	return false
+}
+
+func HashSubscriptionSpec(subscriptionSpec *appsapi.SubscriptionSpec) uint64 {
+	specJSON, _ := json.Marshal(subscriptionSpec)
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	hasher := fnv.New32a()
+	printer.Fprintf(hasher, "%#v", specJSON)
+	return uint64(hasher.Sum32())
 }

--- a/pkg/utils/feed_test.go
+++ b/pkg/utils/feed_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFormatFeed(t *testing.T) {
@@ -255,6 +256,72 @@ func TestHasFeed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := HasFeed(tt.feed, tt.feeds); got != tt.want {
 				t.Errorf("HasFeed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHashSubscriptionSpec(t *testing.T) {
+	tests := []struct {
+		name             string
+		subscriptionSpec *appsapi.SubscriptionSpec
+		want             uint64
+	}{
+		{
+			subscriptionSpec: &appsapi.SubscriptionSpec{
+				SchedulerName:      "default",
+				SchedulingStrategy: "Replication",
+				Subscribers: []appsapi.Subscriber{
+					{
+						ClusterAffinity: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"cluster-name": "abc",
+							},
+							MatchExpressions: nil,
+						},
+					},
+				},
+				ClusterTolerations: nil,
+				Feeds: []appsapi.Feed{
+					{
+						Kind:       "Demo",
+						APIVersion: "abc.com/v1",
+						Namespace:  "foo",
+						Name:       "bar",
+					},
+				},
+			},
+			want: uint64(2608449479),
+		},
+		{
+			subscriptionSpec: &appsapi.SubscriptionSpec{
+				SchedulerName:      "default",
+				SchedulingStrategy: "Replication",
+				Subscribers: []appsapi.Subscriber{
+					{
+						ClusterAffinity: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"cluster-name": "abc",
+							},
+						},
+					},
+				},
+				Feeds: []appsapi.Feed{
+					{
+						Kind:       "Demo",
+						APIVersion: "abc.com/v1",
+						Namespace:  "foo",
+						Name:       "bar",
+					},
+				},
+			},
+			want: uint64(2608449479),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HashSubscriptionSpec(tt.subscriptionSpec); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/apis
kind/feature

#### What this PR does / why we need it:
- migrating scheduling into scheduler framework
- update `Subscription` spec
- add `tainttoleration` plugin
- add `defaultbinder` plugin

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
