### PR TITLE
add support "app.kubernetes.io/component" to find apiserver pod

### DIFF
--- a/pkg/controllers/clusters/clusterstatus/network.go
+++ b/pkg/controllers/clusters/clusterstatus/network.go
@@ -91,9 +91,13 @@ func findPodIPRangeFromNodeSpec(nodeLister corev1Lister.NodeLister) string {
 // findPodCommandParameter returns the pod container command parameter for the given pod.
 // copied from submariner.io/submariner-operator/pkg/discovery/network/pods.go
 func findPodCommandParameter(podLister corev1Lister.PodLister, labelSelectorValue, parameter string) string {
-	pod, err := findPod(podLister, "component", labelSelectorValue)
+	pod := findPodWithComponentLabel(podLister, labelSelectorValue)
 
-	if err != nil || pod == nil {
+	if pod == nil {
+		pod = findPodWithK8sComponentLabel(podLister, labelSelectorValue)
+	}
+
+	if pod == nil {
 		return ""
 	}
 	for _, container := range pod.Spec.Containers {
@@ -106,6 +110,24 @@ func findPodCommandParameter(podLister corev1Lister.PodLister, labelSelectorValu
 		}
 	}
 	return ""
+}
+
+func findPodWithComponentLabel(podLister corev1Lister.PodLister, labelSelectorValue string) *corev1.Pod {
+	pod, err := findPod(podLister, "component", labelSelectorValue)
+
+	if err != nil {
+		return nil
+	}
+	return pod
+}
+
+func findPodWithK8sComponentLabel(podLister corev1Lister.PodLister, labelSelectorValue string) *corev1.Pod {
+	pod, err := findPod(podLister, "app.kubernetes.io/component", labelSelectorValue)
+
+	if err != nil {
+		return nil
+	}
+	return pod
 }
 
 // findPod returns the pods filter by the given labelSelector.

--- a/pkg/controllers/clusters/clusterstatus/network_test.go
+++ b/pkg/controllers/clusters/clusterstatus/network_test.go
@@ -52,8 +52,82 @@ func TestFindPodCommandParameterFromArgs(t *testing.T) {
 
 }
 
+func TestFindPodCommandParameterFromArgsWithK8sLabel(t *testing.T) {
+	podArgs := BuildPod("kube-apiserver", "app.kubernetes.io/component", "kube-apiserver")
+	podArgs.Spec.Containers = []corev1.Container{
+		{
+			Args: []string{"--service-cluster-ip-range=1.2.3.4"},
+		},
+	}
+
+	kubeClient := fake.NewSimpleClientset()
+	kubeFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	podInformer := kubeFactory.Core().V1().Pods()
+
+	err := podInformer.Informer().GetIndexer().Add(podArgs)
+	if err != nil {
+		t.Errorf("Add pod err: %v", err)
+	}
+
+	podArgsLister := podInformer.Lister()
+
+	tests := []struct {
+		description string
+		podLister   corelisters.PodLister
+		expectedIP  string
+	}{
+		{
+			description: "service-cluster-ip-range is in args",
+			podLister:   podArgsLister,
+			expectedIP:  "1.2.3.4",
+		},
+	}
+
+	for _, test := range tests {
+		clusterIPRange := findPodCommandParameter(test.podLister, "kube-apiserver", "--service-cluster-ip-range")
+		if clusterIPRange != test.expectedIP {
+			t.Errorf("get clusteriprange is %v", clusterIPRange)
+		}
+	}
+
+}
+
 func TestFindPodCommandParameterFromCommand(t *testing.T) {
 	podCommand := BuildPod("kube-apiserver", "component", "kube-apiserver")
+	podCommand.Spec.Containers = []corev1.Container{
+		{
+			Command: []string{"--service-cluster-ip-range=1.2.3.4"},
+		},
+	}
+
+	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"namespace": cache.MetaNamespaceIndexFunc})
+	lister := corelisters.NewPodLister(store)
+	if err := store.Add(podCommand); err != nil {
+		t.Errorf("add pod err %v", err)
+	}
+
+	tests := []struct {
+		description string
+		podLister   corelisters.PodLister
+		expectedIP  string
+	}{
+		{
+			description: "service-cluster-ip-range is in command",
+			podLister:   lister,
+			expectedIP:  "1.2.3.4",
+		},
+	}
+
+	for _, test := range tests {
+		clusterIPRange := findPodCommandParameter(test.podLister, "kube-apiserver", "--service-cluster-ip-range")
+		if clusterIPRange != test.expectedIP {
+			t.Errorf("get clusteriprange is %v", clusterIPRange)
+		}
+	}
+}
+
+func TestFindPodCommandParameterFromCommandWithK8sLabel(t *testing.T) {
+	podCommand := BuildPod("kube-apiserver", "app.kubernetes.io/component", "kube-apiserver")
 	podCommand.Spec.Containers = []corev1.Container{
 		{
 			Command: []string{"--service-cluster-ip-range=1.2.3.4"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
support using `component=kube-apiserver`, or `app.kubernetes.io/component=kube-apiserver` to find apiserver pod

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/clusternet/clusternet/issues/223

#### Special notes for your reviewer:
