### PR TITLE
fix bug to support  OCI-based registries

### DIFF
--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"helm.sh/helm/v3/pkg/getter"
-	"helm.sh/helm/v3/pkg/repo"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -789,9 +787,8 @@ func (deployer *Deployer) handleHelmChart(chart *appsapi.HelmChart) error {
 			return err
 		}
 	}
-	_, err = repo.FindChartInAuthRepoURL(chart.Spec.Repository, username, password, chart.Spec.Chart, chart.Spec.ChartVersion,
-		"", "", "",
-		getter.All(utils.Settings))
+
+	_, err = utils.LocateAuthHelmChart(chart.Spec.Repository, username, password, chart.Spec.Chart, chart.Spec.ChartVersion)
 	if err != nil {
 		// failed to find chart
 		return deployer.chartController.UpdateChartStatus(chart, &appsapi.HelmChartStatus{

--- a/pkg/utils/chart.go
+++ b/pkg/utils/chart.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"path"
 	"reflect"
 	"strings"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -62,6 +64,11 @@ func LocateAuthHelmChart(chartRepo, username, password, chartName, chartVersion 
 	client.ChartPathOptions.Version = chartVersion
 	client.ChartPathOptions.Username = username
 	client.ChartPathOptions.Password = password
+
+	if registry.IsOCI(chartRepo) {
+		client.ChartPathOptions.RepoURL = ""
+		chartName = path.Join(chartRepo, chartName)
+	}
 
 	cp, err := client.ChartPathOptions.LocateChart(chartName, Settings)
 	if err != nil {


### PR DESCRIPTION
oci based registries doesn't provide index.yaml. when repo url is an oci address in HelmChart, repo will be shown as "NotFound" status.

This patch fix above issue

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
support to find oci based registry and  download chart from the registry

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #244

#### Special notes for your reviewer:
