### PR TITLE
configurable Helm release name in child clusters

### DIFF
--- a/examples/applications/helm-chart-mysql.yaml
+++ b/examples/applications/helm-chart-mysql.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.clusternet.io/v1alpha1
 kind: HelmChart
 metadata:
-  name: mysql
+  name: mysql # this name will be used as Helm release name as well
   namespace: default
 spec:
   repo: https://charts.bitnami.com/bitnami

--- a/manifests/crds/apps.clusternet.io_helmreleases.yaml
+++ b/manifests/crds/apps.clusternet.io_helmreleases.yaml
@@ -72,6 +72,11 @@ spec:
                   namespace:
                     type: string
                 type: object
+              releaseName:
+                description: ReleaseName specifies the desired release name in child
+                  cluster. If nil, the default release name will be in the format
+                  of "{Description Name}-{HelmChart Namespace}-{HelmChart Name}"
+                type: string
               repo:
                 description: a Helm Repository to be used. OCI-based registries are
                   also supported. For example, https://charts.bitnami.com/bitnami

--- a/pkg/apis/apps/v1alpha1/helm.go
+++ b/pkg/apis/apps/v1alpha1/helm.go
@@ -144,6 +144,13 @@ type HelmRelease struct {
 type HelmReleaseSpec struct {
 	HelmOptions `json:",inline"`
 
+	// ReleaseName specifies the desired release name in child cluster.
+	// If nil, the default release name will be in the format of "{Description Name}-{HelmChart Namespace}-{HelmChart Name}"
+	//
+	// +optional
+	// +kubebuilder:validation:Type=string
+	ReleaseName *string `json:"releaseName,omitempty"`
+
 	// TargetNamespace specifies the namespace to install the chart
 	//
 	// +required

--- a/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -467,7 +467,7 @@ func (in *HelmRelease) DeepCopyInto(out *HelmRelease) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	out.Status = in.Status
 	return
 }
@@ -527,6 +527,11 @@ func (in *HelmReleaseList) DeepCopyObject() runtime.Object {
 func (in *HelmReleaseSpec) DeepCopyInto(out *HelmReleaseSpec) {
 	*out = *in
 	out.HelmOptions = in.HelmOptions
+	if in.ReleaseName != nil {
+		in, out := &in.ReleaseName, &out.ReleaseName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/hub/deployer/helm/helm.go
+++ b/pkg/hub/deployer/helm/helm.go
@@ -296,6 +296,7 @@ func (deployer *Deployer) populateHelmRelease(desc *appsapi.Description) error {
 				},
 			},
 			Spec: appsapi.HelmReleaseSpec{
+				ReleaseName:     utilpointer.String(chart.Name), // default to be the HelmChart name
 				TargetNamespace: chart.Spec.TargetNamespace,
 				HelmOptions:     chart.Spec.HelmOptions,
 			},
@@ -326,6 +327,12 @@ func (deployer *Deployer) syncHelmRelease(desc *appsapi.Description, helmRelease
 	if err == nil {
 		if hr.DeletionTimestamp != nil {
 			return fmt.Errorf("HelmRelease %s is deleting, will resync later", klog.KObj(hr))
+		}
+
+		// backwards compatible
+		// for HelmRelease that are already populated, spec.releaseName should be set to nil
+		if hr.Spec.ReleaseName == nil {
+			helmRelease.Spec.ReleaseName = nil
 		}
 
 		if reflect.DeepEqual(hr.Spec, helmRelease.Spec) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature
kind/api

#### What this PR does / why we need it:
* introduces a new field `spec.releaseName` in `HelmRelease`, which will be set default to the same value as `HelmChart` name;
* keeps backwards compatible, which will not break old populated `HelmRelease` objects;


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #267

#### Special notes for your reviewer:
