### PR TITLE
use healthz to report cluster status with a lower version

### DIFF
--- a/manifests/crds/clusters.clusternet.io_managedclusters.yaml
+++ b/manifests/crds/clusters.clusternet.io_managedclusters.yaml
@@ -37,8 +37,8 @@ spec:
     - jsonPath: .status.k8sVersion
       name: KUBERNETES
       type: string
-    - jsonPath: .status.readyz
-      name: READYZ
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE

--- a/pkg/apis/clusters/v1beta1/types.go
+++ b/pkg/apis/clusters/v1beta1/types.go
@@ -282,7 +282,7 @@ type ManagedClusterStatus struct {
 // +kubebuilder:printcolumn:name="CLUSTER TYPE",type=string,JSONPath=`.spec.clusterType`,description="The type of the cluster",priority=100
 // +kubebuilder:printcolumn:name="SYNC MODE",type=string,JSONPath=`.spec.syncMode`,description="The cluster sync mode"
 // +kubebuilder:printcolumn:name="KUBERNETES",type=string,JSONPath=".status.k8sVersion"
-// +kubebuilder:printcolumn:name="READYZ",type=string,JSONPath=".status.readyz"
+// +kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ManagedCluster is the Schema for the managedclusters API

--- a/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
+++ b/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
@@ -169,7 +169,7 @@ func (c *Controller) getHealthStatus(ctx context.Context, path string) bool {
 }
 
 func (c *Controller) getCondition(status clusterapi.ManagedClusterStatus) metav1.Condition {
-	if status.Livez && status.Readyz {
+	if (status.Livez && status.Readyz) || status.Healthz {
 		return metav1.Condition{
 			Type:               clusterapi.ClusterReady,
 			Status:             metav1.ConditionTrue,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

using healthz as managed cluster's status  to compatible with child clusters whoes  Kubernetes are under  v1.16

#### Which issue(s) this PR fixes:

Fixes #249
xref #137
#### Special notes for your reviewer:
Also replace readyz with contiditions[0].status in displaying a managed clusters
