### PR TITLE
populate Localizations for dividing scheduling

### DIFF
--- a/pkg/hub/deployer/utils.go
+++ b/pkg/hub/deployer/utils.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -103,4 +104,21 @@ func removeFeedFromAllMatchingSubscriptions(clusternetClient *clusternetclientse
 		allErrs = append(allErrs, err)
 	}
 	return utilerrors.NewAggregate(allErrs)
+}
+
+func GenerateLocalizationTemplate(base *appsapi.Base, overridePolicy appsapi.OverridePolicy) *appsapi.Localization {
+	loc := &appsapi.Localization{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: base.Namespace,
+			Labels: map[string]string{
+				known.ObjectCreatedByLabel: known.ClusternetHubName,
+			},
+		},
+		Spec: appsapi.LocalizationSpec{
+			OverridePolicy: overridePolicy,
+			Priority:       500, // use default
+		},
+	}
+	loc.SetOwnerReferences([]metav1.OwnerReference{*metav1.NewControllerRef(base, baseKind)})
+	return loc
 }

--- a/pkg/scheduler/algorithm/dividing/static.go
+++ b/pkg/scheduler/algorithm/dividing/static.go
@@ -36,9 +36,9 @@ func StaticDivideReplicas(selected *framework.TargetClusters, sub *appsapi.Subsc
 		}
 		if order != nil && order.DesiredReplicas != nil {
 			replicas := staticDivideReplicas(*order.DesiredReplicas, &wl)
-			selected.Replicas[utils.GetFeedKey(&order.Feed)] = replicas
+			selected.Replicas[utils.GetFeedKey(order.Feed)] = replicas
 		} else {
-			selected.Replicas[utils.GetFeedKey(&order.Feed)] = []int32{}
+			selected.Replicas[utils.GetFeedKey(order.Feed)] = []int32{}
 		}
 	}
 	return nil

--- a/pkg/scheduler/algorithm/generic_test.go
+++ b/pkg/scheduler/algorithm/generic_test.go
@@ -29,8 +29,8 @@ func newClusterWithLabels(name, namespace string, labels map[string]string) *clu
 	}
 }
 
-func newDeploymentFeed(name string) *appsapi.Feed {
-	return &appsapi.Feed{
+func newDeploymentFeed(name string) appsapi.Feed {
+	return appsapi.Feed{
 		Kind:       "Deployment",
 		APIVersion: "apps/v1",
 		Namespace:  "default",
@@ -71,13 +71,13 @@ func TestDivideReplicas(t *testing.T) {
 								Weight: 1,
 							},
 						},
-						Feeds: []appsapi.Feed{*newDeploymentFeed("example-1")},
+						Feeds: []appsapi.Feed{newDeploymentFeed("example-1")},
 					},
 				},
 				finv: &appsapi.FeedInventory{
 					Spec: appsapi.FeedInventorySpec{Feeds: []appsapi.FeedOrder{
 						{
-							Feed:            *newDeploymentFeed("example-1"),
+							Feed:            newDeploymentFeed("example-1"),
 							DesiredReplicas: &desiredReplicas,
 						},
 					}},
@@ -116,13 +116,13 @@ func TestDivideReplicas(t *testing.T) {
 								Weight: 2,
 							},
 						},
-						Feeds: []appsapi.Feed{*newDeploymentFeed("example-1")},
+						Feeds: []appsapi.Feed{newDeploymentFeed("example-1")},
 					},
 				},
 				finv: &appsapi.FeedInventory{
 					Spec: appsapi.FeedInventorySpec{Feeds: []appsapi.FeedOrder{
 						{
-							Feed:            *newDeploymentFeed("example-1"),
+							Feed:            newDeploymentFeed("example-1"),
 							DesiredReplicas: &desiredReplicas,
 						},
 					}},
@@ -161,13 +161,13 @@ func TestDivideReplicas(t *testing.T) {
 								Weight: 2,
 							},
 						},
-						Feeds: []appsapi.Feed{*newDeploymentFeed("example-1")},
+						Feeds: []appsapi.Feed{newDeploymentFeed("example-1")},
 					},
 				},
 				finv: &appsapi.FeedInventory{
 					Spec: appsapi.FeedInventorySpec{Feeds: []appsapi.FeedOrder{
 						{
-							Feed:            *newDeploymentFeed("example-1"),
+							Feed:            newDeploymentFeed("example-1"),
 							DesiredReplicas: &desiredReplicas,
 						},
 					}},
@@ -214,13 +214,13 @@ func TestDivideReplicas(t *testing.T) {
 								Weight: 2,
 							},
 						},
-						Feeds: []appsapi.Feed{*newDeploymentFeed("example-1")},
+						Feeds: []appsapi.Feed{newDeploymentFeed("example-1")},
 					},
 				},
 				finv: &appsapi.FeedInventory{
 					Spec: appsapi.FeedInventorySpec{Feeds: []appsapi.FeedOrder{
 						{
-							Feed:            *newDeploymentFeed("example-1"),
+							Feed:            newDeploymentFeed("example-1"),
 							DesiredReplicas: &desiredReplicas,
 						},
 					}},
@@ -267,17 +267,17 @@ func TestDivideReplicas(t *testing.T) {
 								Weight: 2,
 							},
 						},
-						Feeds: []appsapi.Feed{*newDeploymentFeed("example-1"), *newDeploymentFeed("example-2")},
+						Feeds: []appsapi.Feed{newDeploymentFeed("example-1"), newDeploymentFeed("example-2")},
 					},
 				},
 				finv: &appsapi.FeedInventory{
 					Spec: appsapi.FeedInventorySpec{Feeds: []appsapi.FeedOrder{
 						{
-							Feed:            *newDeploymentFeed("example-1"),
+							Feed:            newDeploymentFeed("example-1"),
 							DesiredReplicas: &desiredReplicas,
 						},
 						{
-							Feed:            *newDeploymentFeed("example-2"),
+							Feed:            newDeploymentFeed("example-2"),
 							DesiredReplicas: &desiredReplicas,
 						},
 					}},

--- a/pkg/utils/feed.go
+++ b/pkg/utils/feed.go
@@ -175,7 +175,7 @@ func HashSubscriptionSpec(subscriptionSpec *appsapi.SubscriptionSpec) uint64 {
 	return uint64(hasher.Sum32())
 }
 
-func GetFeedKey(feed *appsapi.Feed) string {
+func GetFeedKey(feed appsapi.Feed) string {
 	if len(feed.Namespace) != 0 {
 		return fmt.Sprintf("%s/%s/%s/%s", feed.APIVersion, feed.Kind, feed.Namespace, feed.Name)
 	} else {


### PR DESCRIPTION
Signed-off-by: Di Xu <stephenhsu90@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
For dividing scheduling, overrides for `replicas` are needed per child cluster.
In this PR, **Localizations** are used to set overrides for `replicas` based on the `replicaJsonPath` from `FeedInventory`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
