### PR TITLE
fix: releasename when deploy helm charts

### DIFF
--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -167,7 +167,7 @@ func ReconcileHelmRelease(ctx context.Context, deployCtx *DeployContext, kubeCli
 
 	var rel *release.Release
 	// check whether the release is deployed
-	rel, err = cfg.Releases.Deployed(hr.Name)
+	rel, err = cfg.Releases.Deployed(releaseName)
 	if err != nil {
 		if strings.Contains(err.Error(), driver.ErrNoDeployedReleases.Error()) {
 			rel, err = InstallRelease(cfg, releaseName, hr.Spec.TargetNamespace, chart, overrideValues)


### PR DESCRIPTION
#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:

`releaseName` now use helm chart name, while `hr.Name` is prefixed with namespace and other info, this will cause helm upgrade failed 