### PR TITLE
fix resource already exists for shadow apis

### DIFF
--- a/pkg/registry/shadow/template/trimmer.go
+++ b/pkg/registry/shadow/template/trimmer.go
@@ -30,6 +30,8 @@ func trimCommonMetadata(result *unstructured.Unstructured) {
 	unstructured.RemoveNestedField(result.Object, "metadata", "creationTimestamp")
 	unstructured.RemoveNestedField(result.Object, "metadata", "managedFields")
 	unstructured.RemoveNestedField(result.Object, "metadata", "resourceVersion")
+	unstructured.RemoveNestedField(result.Object, "metadata", "selfLink")
+	unstructured.RemoveNestedField(result.Object, "metadata", "uid")
 }
 
 func trimCoreService(result *unstructured.Unstructured) {

--- a/pkg/registry/shadow/template/trimmer_test.go
+++ b/pkg/registry/shadow/template/trimmer_test.go
@@ -43,6 +43,7 @@ func TestTrimCoreService(t *testing.T) {
 						"name":            "my-test-nodeport-svc",
 						"namespace":       "nginx-test",
 						"resourceVersion": "4457294",
+						"selfLink":        "test-link",
 						"uid":             "28f5ae38-9eea-431c-918b-68ffdf263c24",
 					},
 					"spec": map[string]interface{}{
@@ -87,7 +88,6 @@ func TestTrimCoreService(t *testing.T) {
 						},
 						"name":      "my-test-nodeport-svc",
 						"namespace": "nginx-test",
-						"uid":       "28f5ae38-9eea-431c-918b-68ffdf263c24",
 					},
 					"spec": map[string]interface{}{
 						"clusterIP": "10.98.177.115",
@@ -210,7 +210,6 @@ func TestTrimBatchJob(t *testing.T) {
 						},
 						"name":      "pi",
 						"namespace": "default",
-						"uid":       "dc8ca8aa-268c-4634-b1f7-6bf67e3af6cb",
 					},
 					"spec": map[string]interface{}{
 						"backoffLimit": 4,


### PR DESCRIPTION
Signed-off-by: Di Xu <stephenhsu90@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
Failed to create a shadow resource with `dryRun` when real resource existed in the apiserver with the same name. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #315

#### Special notes for your reviewer:
