### PR TITLE
move owned-by-description label as annotation

### DIFF
--- a/pkg/agent/deployer/generic/generic.go
+++ b/pkg/agent/deployer/generic/generic.go
@@ -179,7 +179,7 @@ func (deployer *Deployer) handleResource(ownedByValue string) error {
 	// get description ns and name
 	parts := strings.Split(ownedByValue, ".")
 	if len(parts) < 2 {
-		return fmt.Errorf("unexpected value for label %s: %s", known.ObjectOwnedByDescriptionLabel, ownedByValue)
+		return fmt.Errorf("unexpected value for annotation %s: %s", known.ObjectOwnedByDescriptionAnnotation, ownedByValue)
 	}
 	// namespace contains no ".", while name does
 	namespace := parts[0]

--- a/pkg/controllers/apps/resource/resource.go
+++ b/pkg/controllers/apps/resource/resource.go
@@ -68,7 +68,7 @@ func NewController(apiResource *metav1.APIResource, clusternetClient *versioned.
 	ri := utils.NewResourceInformer(resourceClient, apiResource, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			resource := obj.(*unstructured.Unstructured)
-			val, ok := resource.GetLabels()[known.ObjectOwnedByDescriptionLabel]
+			val, ok := resource.GetAnnotations()[known.ObjectOwnedByDescriptionAnnotation]
 			if ok {
 				klog.V(4).Infof("adding %s %q", c.name, klog.KObj(resource))
 				c.enqueue(val)
@@ -76,7 +76,7 @@ func NewController(apiResource *metav1.APIResource, clusternetClient *versioned.
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			resource := oldObj.(*unstructured.Unstructured)
-			val, ok := resource.GetLabels()[known.ObjectOwnedByDescriptionLabel]
+			val, ok := resource.GetAnnotations()[known.ObjectOwnedByDescriptionAnnotation]
 			if ok {
 				klog.V(4).Infof("updating %s %q", c.name, klog.KObj(resource))
 				c.enqueue(val)
@@ -84,7 +84,7 @@ func NewController(apiResource *metav1.APIResource, clusternetClient *versioned.
 		},
 		DeleteFunc: func(obj interface{}) {
 			resource := obj.(*unstructured.Unstructured)
-			val, ok := resource.GetLabels()[known.ObjectOwnedByDescriptionLabel]
+			val, ok := resource.GetAnnotations()[known.ObjectOwnedByDescriptionAnnotation]
 			if ok {
 				klog.V(4).Infof("deleting %s %q", c.name, klog.KObj(resource))
 				c.enqueue(val)

--- a/pkg/known/annotations.go
+++ b/pkg/known/annotations.go
@@ -27,4 +27,7 @@ const (
 	// SkipValidatingAnnotation indicates no validations will be applied when dry-run on shadow resources.
 	// This is useful when you want to create a CR, but you don't want to declare a CRD in the parent kube-apiserver.
 	SkipValidatingAnnotation = "apps.clusternet.io/skip-validating"
+
+	//ObjectOwnedByDescriptionAnnotation is the name of an annotation which contains the description of the object owned by
+	ObjectOwnedByDescriptionAnnotation = "apps.clusternet.io/owned-by-description"
 )

--- a/pkg/known/labels.go
+++ b/pkg/known/labels.go
@@ -23,8 +23,7 @@ const (
 	ClusterNameLabel          = "clusters.clusternet.io/cluster-name"
 	ClusterBootstrappingLabel = "clusters.clusternet.io/bootstrapping"
 
-	ObjectCreatedByLabel          = "clusternet.io/created-by"
-	ObjectOwnedByDescriptionLabel = "apps.clusternet.io/owned-by-description"
+	ObjectCreatedByLabel = "clusternet.io/created-by"
 
 	// the source info where this object belongs to or controlled by
 	ConfigGroupLabel     = "apps.clusternet.io/config.group"

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -321,12 +321,12 @@ func ApplyDescription(ctx context.Context, clusternetClient *clusternetclientset
 			continue
 		}
 
-		labels := resource.GetLabels()
-		if labels == nil {
-			labels = map[string]string{}
+		annotations := resource.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
 		}
-		labels[known.ObjectOwnedByDescriptionLabel] = desc.Namespace + "." + desc.Name
-		resource.SetLabels(labels)
+		annotations[known.ObjectOwnedByDescriptionAnnotation] = desc.Namespace + "." + desc.Name
+		resource.SetAnnotations(annotations)
 		wg.Add(1)
 		go func(resource *unstructured.Unstructured) {
 			defer wg.Done()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Because labels value have a length limit, move the labels field `apps.clusternet.io/owned-by-description` into annotations

#### What this PR does / why we need it:

```
reason: 'ConfigMap "agent--train-05101029-hc-13z" is invalid: metadata.labels: Invalid
    value: "clusternet-9rkxk.agent--train-05101029-hc-13z-n2hsxsj66k2r-generic": must
    be no more than 63 characters'
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #325 

#### Special notes for your reviewer:
