### PR TITLE
aggregate common labels from nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
 	helm.sh/helm/v3 v3.8.0
 	k8s.io/api v0.23.1
 	k8s.io/apiextensions-apiserver v0.23.1
@@ -125,7 +126,6 @@ require (
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/pkg/agent/status_manager.go
+++ b/pkg/agent/status_manager.go
@@ -18,13 +18,17 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"reflect"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -131,6 +135,15 @@ func (mgr *Manager) updateClusterStatus(ctx context.Context, namespace, clusterI
 			return false, nil
 		}
 
+		newLabels := mgr.getManagedClusterNewLabels()
+		if !reflect.DeepEqual(mgr.managedCluster.GetLabels(), newLabels) {
+			mcls, lastError = patchManagedClusterTwoWayMergeLabels(client, mgr.managedCluster, newLabels)
+			if lastError == nil {
+				mgr.managedCluster = mcls
+			} else {
+				return false, nil
+			}
+		}
 		mgr.managedCluster.Status = *status
 		mcls, lastError = client.ClustersV1beta1().ManagedClusters(namespace).UpdateStatus(ctx, mgr.managedCluster, metav1.UpdateOptions{})
 		if lastError == nil {
@@ -148,4 +161,39 @@ func (mgr *Manager) updateClusterStatus(ctx context.Context, namespace, clusterI
 	if err != nil {
 		klog.WarningDepth(2, "failed to update status of ManagedCluster: %v", lastError)
 	}
+}
+
+func (mgr *Manager) getManagedClusterNewLabels() map[string]string {
+	originLabels := mgr.managedCluster.GetLabels()
+	modifiedLabels := map[string]string{}
+	for k, v := range originLabels {
+		if strings.HasPrefix(k, known.NodeLabelsKeyPrefix) {
+			continue
+		}
+		modifiedLabels[k] = v
+	}
+	return labels.Merge(modifiedLabels, mgr.clusterStatusController.GetManagedClusterLabels())
+}
+
+func patchManagedClusterTwoWayMergeLabels(client clusternetclientset.Interface, mcls *clusterapi.ManagedCluster,
+	newLabels map[string]string) (result *clusterapi.ManagedCluster, err error) {
+	actualCopy := mcls.DeepCopy()
+	actualCopy.Labels = newLabels
+
+	oldData, err := json.Marshal(mcls)
+	if err != nil {
+		return nil, err
+	}
+
+	newData, err := json.Marshal(actualCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, clusterapi.ManagedCluster{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.ClustersV1beta1().ManagedClusters(mcls.Namespace).Patch(context.TODO(), mcls.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 }

--- a/pkg/controllers/clusters/clusterstatus/clusterstatus_controller_test.go
+++ b/pkg/controllers/clusters/clusterstatus/clusterstatus_controller_test.go
@@ -1,0 +1,61 @@
+package clusterstatus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func BuildNode(name string, labels map[string]string) *corev1.Node {
+	node := &corev1.Node{
+		TypeMeta: metav1.TypeMeta{Kind: "Node"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+	return node
+}
+
+type StatusSuite struct {
+	nodes []*corev1.Node
+	suite.Suite
+}
+
+func TestDeployment(t *testing.T) {
+	suite.Run(t, new(StatusSuite))
+}
+
+func (suite *StatusSuite) SetupTest() {
+	suite.nodes = []*corev1.Node{
+		0: BuildNode("node0", map[string]string{
+			"node.clusternet.io/k1": "v1",
+			"node.clusternet.io/k2": "v2",
+		}),
+		1: BuildNode("node1", map[string]string{
+			"node.clusternet.io/k1": "v1",
+			"node.clusternet.io/k2": "v2",
+			"node.clusternet.io/k3": "v3",
+		}),
+		2: BuildNode("node2", map[string]string{
+			"node.clusternet.io/k1": "v1",
+			"node.clusternet.io/k2": "v2",
+			"node.clusternet.io/k4": "v4",
+		}),
+		3: BuildNode("node3", map[string]string{
+			"node.clusternet.io/k1": "v1",
+			"node.clusternet.io/k2": "v2",
+			"node.clusternet.io/k3": "v3",
+			"node.clusternet.io/k4": "v4",
+		}),
+	}
+}
+
+func (suite *StatusSuite) TestGetCommonNodeLabels() {
+	commonLabels := getCommonNodeLabels(suite.nodes)
+	suite.Equal(
+		map[string]string{"node.clusternet.io/k1": "v1", "node.clusternet.io/k2": "v2"},
+		commonLabels, "failed get common labels from nodes")
+}

--- a/pkg/known/labels.go
+++ b/pkg/known/labels.go
@@ -18,6 +18,7 @@ package known
 
 // label key
 const (
+	NodeLabelsKeyPrefix       = "node.clusternet.io/"
 	ClusterRegisteredByLabel  = "clusters.clusternet.io/registered-by"
 	ClusterIDLabel            = "clusters.clusternet.io/cluster-id"
 	ClusterNameLabel          = "clusters.clusternet.io/cluster-name"


### PR DESCRIPTION
Signed-off-by: lmxia <xialingming@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Add feature about aggregate nodes common labels to mcls.

#### What this PR does / why we need it:
Managedcluster's labels precisely represent nodes in child cluster.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
1. Aggreate labels start with ``node.clusternet.io/`` 
2. Keep managedclusters existed labels.
3. Updated 3 minites periodly default.