### PR TITLE
fix bug of aggregate single node labels with no filter

### DIFF
--- a/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
+++ b/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
@@ -348,11 +348,8 @@ func getCommonNodeLabels(nodes []*corev1.Node) map[string]string {
 	if len(nodes) == 0 {
 		return nil
 	}
-	if len(nodes) == 1 {
-		return nodes[0].Labels
-	}
 	initLabels := nodes[0].Labels
-	for _, node := range nodes[1:] {
+	for _, node := range nodes {
 		currentLabels := map[string]string{}
 		for k, v := range node.Labels {
 			c, ok := initLabels[k]

--- a/pkg/controllers/clusters/clusterstatus/clusterstatus_controller_test.go
+++ b/pkg/controllers/clusters/clusterstatus/clusterstatus_controller_test.go
@@ -33,11 +33,13 @@ func (suite *StatusSuite) SetupTest() {
 		0: BuildNode("node0", map[string]string{
 			"node.clusternet.io/k1": "v1",
 			"node.clusternet.io/k2": "v2",
+			"others.keys.io/k2":     "a1",
 		}),
 		1: BuildNode("node1", map[string]string{
 			"node.clusternet.io/k1": "v1",
 			"node.clusternet.io/k2": "v2",
 			"node.clusternet.io/k3": "v3",
+			"others.keys.io/k2":     "a1",
 		}),
 		2: BuildNode("node2", map[string]string{
 			"node.clusternet.io/k1": "v1",
@@ -56,6 +58,19 @@ func (suite *StatusSuite) SetupTest() {
 func (suite *StatusSuite) TestGetCommonNodeLabels() {
 	commonLabels := getCommonNodeLabels(suite.nodes)
 	suite.Equal(
-		map[string]string{"node.clusternet.io/k1": "v1", "node.clusternet.io/k2": "v2"},
+		map[string]string{
+			"node.clusternet.io/k1": "v1",
+			"node.clusternet.io/k2": "v2",
+		},
+		commonLabels, "failed get common labels from nodes")
+}
+
+func (suite *StatusSuite) TestGetSingleNodeCommonNodeLabels() {
+	commonLabels := getCommonNodeLabels(suite.nodes[0:1])
+	suite.Equal(
+		map[string]string{
+			"node.clusternet.io/k1": "v1",
+			"node.clusternet.io/k2": "v2",
+		},
 		commonLabels, "failed get common labels from nodes")
 }


### PR DESCRIPTION
Signed-off-by: lmxia <xialingming@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
When cluster has only one node, the labels aggregated from sub-cluster does not filter specific prefixed label.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
A follow-up fix of #396 

#### Special notes for your reviewer:
