### PR TITLE
ignore missing key error during json patch

### DIFF
--- a/pkg/hub/localizer/localizer.go
+++ b/pkg/hub/localizer/localizer.go
@@ -274,13 +274,12 @@ func (l *Localizer) handleGlobalization(glob *appsapi.Globalization) error {
 
 func (l *Localizer) ApplyOverridesToDescription(desc *appsapi.Description) error {
 	var allErrs []error
-	descCopy := desc.DeepCopy()
-	switch descCopy.Spec.Deployer {
+	switch desc.Spec.Deployer {
 	case appsapi.DescriptionHelmDeployer:
-		desc.Spec.Raw = make([][]byte, len(descCopy.Spec.Charts))
+		desc.Spec.Raw = make([][]byte, len(desc.Spec.Charts))
 
-		for idx, chartRef := range descCopy.Spec.Charts {
-			overrides, err := l.getOverrides(descCopy.Namespace, appsapi.Feed{
+		for idx, chartRef := range desc.Spec.Charts {
+			overrides, err := l.getOverrides(desc.Namespace, appsapi.Feed{
 				Kind:       chartKind.Kind,
 				APIVersion: chartKind.Version,
 				Namespace:  chartRef.Namespace,
@@ -321,14 +320,14 @@ func (l *Localizer) ApplyOverridesToDescription(desc *appsapi.Description) error
 		}
 		return utilerrors.NewAggregate(allErrs)
 	case appsapi.DescriptionGenericDeployer:
-		for idx, rawObject := range descCopy.Spec.Raw {
+		for idx, rawObject := range desc.Spec.Raw {
 			obj := &unstructured.Unstructured{}
 			if err := json.Unmarshal(rawObject, obj); err != nil {
 				allErrs = append(allErrs, err)
 				continue
 			}
 
-			overrides, err := l.getOverrides(descCopy.Namespace, appsapi.Feed{
+			overrides, err := l.getOverrides(desc.Namespace, appsapi.Feed{
 				Kind:       obj.GetKind(),
 				APIVersion: obj.GetAPIVersion(),
 				Namespace:  obj.GetNamespace(),
@@ -348,7 +347,7 @@ func (l *Localizer) ApplyOverridesToDescription(desc *appsapi.Description) error
 		}
 		return utilerrors.NewAggregate(allErrs)
 	default:
-		return fmt.Errorf("unsupported deployer %s", descCopy.Spec.Deployer)
+		return fmt.Errorf("unsupported deployer %s", desc.Spec.Deployer)
 	}
 }
 

--- a/pkg/hub/localizer/patch.go
+++ b/pkg/hub/localizer/patch.go
@@ -103,10 +103,13 @@ func applyJSONPatch(cur, overrideBytes []byte) ([]byte, error) {
 			maxJSONPatchOperations, len(patchObj))
 	}
 	patchedJS, err := patchObj.Apply(cur)
-	if err != nil && !errors.Is(err, jsonpatch.ErrMissing) {
-		return nil, err
+	if err == nil {
+		return patchedJS, nil
 	}
-	return patchedJS, nil
+	if errors.Is(err, jsonpatch.ErrMissing) {
+		return cur, nil
+	}
+	return nil, err
 }
 
 func applyHelmValuesOverride(currentByte, overrideByte []byte) ([]byte, error) {


### PR DESCRIPTION
Signed-off-by: Di Xu <stephenhsu90@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
introduced by #385

During json patch, any missing key errors should be ignored. **Also unchanged original value should be returned.**

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
This bug does not affect any previous releases.