### PR TITLE
ignore custom metrics api group

### DIFF
--- a/pkg/hub/apiserver/shadow/apiserver.go
+++ b/pkg/hub/apiserver/shadow/apiserver.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	apiservicelisters "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
+	custommetricsapi "k8s.io/metrics/pkg/apis/custom_metrics"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 
 	shadowinstall "github.com/clusternet/clusternet/pkg/apis/shadow/install"
@@ -164,7 +165,6 @@ func (ss *ShadowAPIServer) InstallShadowAPIGroups(stopCh <-chan struct{}, cl dis
 	if err != nil {
 		return err
 	}
-
 	shadowv1alpha1storage := map[string]rest.Storage{}
 	for _, apiGroupResource := range apiGroupResources {
 		// no need to duplicate xxx.clusternet.io
@@ -181,6 +181,11 @@ func (ss *ShadowAPIServer) InstallShadowAPIGroups(stopCh <-chan struct{}, cl dis
 		// where PodMetrics uses pods as resource name, NodeMetrics uses nodes as resource name
 		// which conflicts with corev1.Pod and corev1.Node
 		if apiGroupResource.Group.Name == metricsapi.GroupName {
+			continue
+		}
+
+		// ignore "custom.metrics.k8s.io" group
+		if apiGroupResource.Group.Name == custommetricsapi.GroupName {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: silenceper <silenceper@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

fix panic when prometheus adapter enabled.

```
F0810 08:51:48.348909       1 hooks.go:202] PostStartHook "start-clusternet-hub-shadowapis" failed: unable to install api resources: unable to setup API &{[shadow/v1alpha1] map[v1alpha1:map[apise
rvices:0xc001202370 apiservices.apiregistration.k8s.io/aggregator_openapi_v2_regeneration_count:0xc001295970
.........
.........
 missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_rule_evaluation_duration_seconds, missi
ng parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_rule_evaluation_duration_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_rule_evaluation_dura
tion_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_rule_group_duration_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_rule_gro
up_duration_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_rule_group_duration_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/promet
heus_sd_consul_rpc_duration_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_consul_rpc_duration_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jo
bs.batch/prometheus_sd_consul_rpc_duration_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_consul_rpc_failures, missing parent storage: "jobs.batch", error in registering resourc
e: jobs.batch/prometheus_sd_discovered_targets, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_dns_lookup_failures, missing parent storage: "jobs.batch", error in registering resource: jobs.
batch/prometheus_sd_dns_lookups, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_failed_configs, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_
file_read_errors, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_file_scan_duration_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_fil
e_scan_duration_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_file_scan_duration_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/
prometheus_sd_kubernetes_events, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_http_request, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prome
theus_sd_kubernetes_http_request_duration_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_http_request_duration_seconds_sum, missing parent storage: "jobs.batch", er
ror in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_depth, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_items, missing parent storage: "jobs.bat
ch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_latency_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_latency_seconds_s
um, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/pro
metheus_sd_kubernetes_workqueue_unfinished_work_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_work_duration_seconds_count, missing parent storage: "jobs.batch"
, error in registering resource: jobs.batch/prometheus_sd_kubernetes_workqueue_work_duration_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_received_updates, missing parent stor
age: "jobs.batch", error in registering resource: jobs.batch/prometheus_sd_updates, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_interval_length_seconds, missing parent storage: "jobs.
batch", error in registering resource: jobs.batch/prometheus_target_interval_length_seconds_count, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_interval_length_seconds_sum, missing par
ent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_metadata_cache_bytes, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_metadata_cache_entries, missin
g parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_reload_length_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_reload_length_seconds_co
unt, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_reload_length_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrape_po
ol_exceeded_target_limit, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrape_pool_reloads, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_t
arget_scrape_pool_reloads_failed, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrape_pool_sync, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometh
eus_target_scrape_pool_targets, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrape_pools, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_ta
rget_scrape_pools_failed, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrapes_cache_flush_forced, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prome
theus_target_scrapes_exceeded_sample_limit, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrapes_sample_duplicate_timestamp, missing parent storage: "jobs.batch", error in registering 
resource: jobs.batch/prometheus_target_scrapes_sample_out_of_bounds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_scrapes_sample_out_of_order, missing parent storage: "jobs.batch", err
or in registering resource: jobs.batch/prometheus_target_sync_length_seconds, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_target_sync_length_seconds_count, missing parent storage: "jobs.batc
h", error in registering resource: jobs.batch/prometheus_target_sync_length_seconds_sum, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_template_text_expansion_failures, missing parent storage:
 "jobs.batch", error in registering resource: jobs.batch/prometheus_template_text_expansions, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_treecache_watcher_goroutines, missing parent storage
: "jobs.batch", error in registering resource: jobs.batch/prometheus_treecache_zookeeper_failures, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_tsdb_blocks_loaded, missing parent storage: "jo
bs.batch", error in registering resource: jobs.batch/prometheus_tsdb_checkpoint_creations, missing parent storage: "jobs.batch", error in registering resource: jobs.batch/prometheus_tsdb_checkpoint_creations_failed, missing parent storag
e: "jobs.batch", error in registering resource: jobs.batch/prometheus_tsdb_checkpoint_deletions, missing parent storage: "jobs.batch", error in re
```

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
