### PR TITLE
replace io/ioutil package with io package

### DIFF
--- a/pkg/predictor/server.go
+++ b/pkg/predictor/server.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync/atomic"
 
@@ -208,7 +208,7 @@ func (s *Server) installDefaultHandlers(ctx context.Context) {
 
 	ws.Route(ws.POST(schedulerapi.SubPathPredict).To(func(request *restful.Request, response *restful.Response) {
 		defer request.Request.Body.Close()
-		data, err := ioutil.ReadAll(request.Request.Body)
+		data, err := io.ReadAll(request.Request.Body)
 		if err != nil {
 			http.Error(response, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/scheduler/framework/plugins/predictor/predictor.go
+++ b/pkg/scheduler/framework/plugins/predictor/predictor.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -126,7 +126,7 @@ func predictMaxAcceptableReplicas(httpClient *http.Client, address string, requi
 	}
 
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/cleanup

#### What this PR does / why we need it:
Deprecated: As of Go 1.16, this function simply calls io.ReadAll.
`clusternet` is currently using go 1.17.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
