### PR TITLE
add mcs example

### DIFF
--- a/examples/scheduling-with-mcs-api/scheduling/nginx-deployment.yaml
+++ b/examples/scheduling-with-mcs-api/scheduling/nginx-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: baz
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+  namespace: baz
+  labels:
+    clusternet-app: multi-cluster-nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 6
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 500m
+            limits:
+              memory: 256Mi
+              cpu: 500m
+        - name: redis # only for testing
+          image: redis:6.2
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 500m
+            limits:
+              memory: 256Mi
+              cpu: 500m

--- a/examples/scheduling-with-mcs-api/scheduling/nginx-svc.yaml
+++ b/examples/scheduling-with-mcs-api/scheduling/nginx-svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx-svc
+  namespace: baz
+  labels:
+    app: nginx
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+  selector:
+    app: nginx

--- a/examples/scheduling-with-mcs-api/scheduling/service-export.yaml
+++ b/examples/scheduling-with-mcs-api/scheduling/service-export.yaml
@@ -1,0 +1,7 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: my-nginx-svc # must be same to service name
+  namespace: baz
+  labels:
+    apps.clusternet.io/subs.namespace: default

--- a/examples/scheduling-with-mcs-api/scheduling/subscription.yaml
+++ b/examples/scheduling-with-mcs-api/scheduling/subscription.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps.clusternet.io/v1alpha1
+kind: Subscription
+metadata:
+  name: scheduling-with-mcs-api
+  namespace: default
+spec:
+  subscribers: # defines the clusters to be distributed to
+    - clusterAffinity:
+        matchLabels:
+          clusters.clusternet.io/cluster-id: dc91021d-2361-4f6d-a404-7c33b9e01118 # PLEASE UPDATE THIS CLUSTER-ID TO YOURS!!!
+      weight: 1 # Deployment bar/my-nginx will have 2 replicas running in this cluster
+    - clusterAffinity:
+        matchLabels:
+          clusters.clusternet.io/cluster-id: 5f9da921-0437-4fea-a89d-42aa1ede9b25 # PLEASE UPDATE THIS CLUSTER-ID TO YOURS!!!
+      weight: 2 # Deployment bar/my-nginx will have 4 replicas running in this cluster
+  schedulingStrategy: Dividing
+  dividingScheduling:
+    type: Static
+  feeds: # defines all the resources to be deployed with
+    - apiVersion: v1
+      kind: Namespace
+      name: baz
+    - apiVersion: v1
+      kind: Service
+      name: my-nginx-svc
+      namespace: baz
+    - apiVersion: apps/v1 # with a total of 101 replicas
+      kind: Deployment
+      name: my-nginx
+      namespace: baz
+    - apiVersion:  multicluster.x-k8s.io/v1alpha1
+      kind: ServiceExport
+      name: my-nginx-svc
+      namespace: baz

--- a/examples/scheduling-with-mcs-api/service-import.yaml
+++ b/examples/scheduling-with-mcs-api/service-import.yaml
@@ -1,0 +1,17 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceImport
+metadata:
+  name: my-svc
+  namespace: default
+  labels:
+    services.clusternet.io/multi-cluster-service-name: my-nginx-svc
+    services.clusternet.io/multi-cluster-service-namespace: baz
+spec:
+  ips:
+    - 42.42.42.42 # can be used to access this derived service from outside this cluster.
+  type: "ClusterSetIP"
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+  sessionAffinity: None


### PR DESCRIPTION
Signed-off-by: lmxia <xialingming@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Example add.
#### What this PR does / why we need it:
Add multi cluster service related examples.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

May add doc description about this example, notice multi-cluster-service has prerequiement for network condition.

First apply workload to child cluster.

 `kubectl clusternet applay -f examples/scheduling-with-mcs-api/scheduling`

Then apply service import object in parent cluster.

`kubectl create -f examples/scheduling-with-mcs-api/service-import.yaml`