### PR TITLE
FeedInventories not found sometime

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -252,10 +252,8 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 	if sub.Spec.SchedulingStrategy == appsapi.DividingSchedulingStrategyType {
 		finv, err = sched.inventoryLister.FeedInventories(ns).Get(name)
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				utilruntime.HandleError(err)
-				sched.SchedulingQueue.AddRateLimited(key)
-			}
+			utilruntime.HandleError(err)
+			sched.SchedulingQueue.AddRateLimited(key)
 			return
 		}
 		feeds := make([]appsapi.Feed, 0, len(finv.Spec.Feeds))


### PR DESCRIPTION
Signed-off-by: silenceper <silenceper@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
FeedInventories has been created, but the cache has not been updated and cannot be obtained.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
