### PR TITLE
rewire MaxHistory for chart Upgrade action

### DIFF
--- a/pkg/utils/chart.go
+++ b/pkg/utils/chart.go
@@ -171,6 +171,7 @@ func InstallRelease(cfg *action.Configuration, hr *appsapi.HelmRelease,
 func UpgradeRelease(cfg *action.Configuration, hr *appsapi.HelmRelease,
 	chart *chart.Chart, vals map[string]interface{}) (*release.Release, error) {
 	client := action.NewUpgrade(cfg)
+	client.MaxHistory = cfg.Releases.MaxHistory // need to rewire it here
 	client.Timeout = time.Duration(hr.Spec.TimeoutSeconds) * time.Second
 	client.Namespace = hr.Spec.TargetNamespace
 	if hr.Spec.Atomic != nil {


### PR DESCRIPTION
Signed-off-by: Di Xu <stephenhsu90@gmail.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
Helm chart `Upgrade` action did not inherit `MaxHistory` from cfg, which sets to 0 by default.

This PR rewires `MaxHistory` from `cfg`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #483 

#### Special notes for your reviewer:
