### PR TITLE
pass down extra headers with prefix clusternet

### DIFF
--- a/pkg/known/headers.go
+++ b/pkg/known/headers.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package known
+
+import "fmt"
+
+const (
+	HeaderPrefixKey = "Clusternet-"
+)
+
+var (
+	TokenHeaderKey       = fmt.Sprintf("%sToken", HeaderPrefixKey)
+	CertificateHeaderKey = fmt.Sprintf("%sCertificate", HeaderPrefixKey)
+	PrivateKeyHeaderKey  = fmt.Sprintf("%sPrivateKey", HeaderPrefixKey)
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
Extra headers prefixing with `clusternet` will be passed down when proxying `CONNECT`.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #488 

#### Special notes for your reviewer:
