### PR TITLE
Fix non-nil pointer error about ClusterRoleBindingList

### DIFF
--- a/pkg/registry/shadow/printers/internalversion/printers.go
+++ b/pkg/registry/shadow/printers/internalversion/printers.go
@@ -2103,7 +2103,7 @@ func printClusterRoleBinding(unstruct *unstructured.Unstructured, options printe
 
 // Prints the ClusterRoleBinding in a human-friendly format.
 func printClusterRoleBindingList(unstructList *unstructured.UnstructuredList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
-	list := rbacv1.ClusterRoleBindingList{}
+	list := &rbacv1.ClusterRoleBindingList{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructList.UnstructuredContent(), list); err != nil {
 		return nil, fmt.Errorf("unable to convert unstructured object to ClusterRoleBindingList %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

when execute "kubectl clusternet get clusterrolebinding" command，will get error "requires a non-nil pointer to an object, got v1.ClusterRoleBindingList".

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
