### PR TITLE
fix: mcs-api guarantee the ServiceImport ports' name and the port of service located on child cluster are same

### DIFF
--- a/examples/scheduling-with-mcs-api/service-import.yaml
+++ b/examples/scheduling-with-mcs-api/service-import.yaml
@@ -11,7 +11,6 @@ spec:
     - 42.42.42.42 # can be used to access this derived service from outside this cluster.
   type: "ClusterSetIP"
   ports:
-    - name: http
-      protocol: TCP
+    - protocol: TCP # the ports' name field must be the same as the service on the child cluster
       port: 80
   sessionAffinity: None


### PR DESCRIPTION


#### What type of PR is this?
Fix

#### What this PR does / why we need it:

The Service created through ServiceImport can’t find the corresponding endpointslices.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #508 


