### PR TITLE
add list verb to clusternet:hub clusterRole

### DIFF
--- a/deploy/hub/clusternet_hub_rbac.yaml
+++ b/deploy/hub/clusternet_hub_rbac.yaml
@@ -7,7 +7,7 @@ rules:
     resources: [ "*" ]
     verbs: [ "*" ]
   - nonResourceURLs: [ "*" ]
-    verbs: [ "get" ]
+    verbs: [ "get" ,"list" ]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
fix "permission for list on /apis/shadow/v1alpha1 not verify" error


#### What this PR does / why we need it:
after updating clusterNet hub from v0.11.0 to v0.12.0,  it seems to have some permission errors.

I1031 11:07:47.296085       1 authorization.go:73] "Forbidden" URI="/apis/shadow/v1alpha1" Reason="permission for list on /apis/shadow/v1alpha1 not verify"
I1031 11:07:47.296163       1 httplog.go:129] "HTTP" verb="GET" URI="/apis/shadow/v1alpha1" latency="639.161504ms" userAgent="Go-http-client/2.0" audit-ID="61a9061c-0e1d-4068-87ba-b73026a9c897" srcIP="192.168.0.128:53454" apf_pl="catch-all" apf_fs="catch-all" apf_fd="" resp=403
I1031 11:07:47.312608       1 authorization.go:73] "Forbidden" URI="/apis/shadow/v1alpha1" Reason="permission for list on /apis/shadow/v1alpha1 not verify"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
