### PR TITLE
fix merging TargetClusters

### DIFF
--- a/pkg/scheduler/framework/interfaces/types.go
+++ b/pkg/scheduler/framework/interfaces/types.go
@@ -132,7 +132,7 @@ func (t *TargetClusters) Merge(b *TargetClusters) {
 			// this cluster is a new one, we should append
 			t.BindingClusters = append(t.BindingClusters, bCluster)
 			for feed, tReplicas := range t.Replicas {
-				if len(tReplicas) != 0 {
+				if len(tReplicas) != 0 && len(tReplicas) < len(t.BindingClusters) {
 					t.Replicas[feed] = append(t.Replicas[feed], 0)
 				}
 			}
@@ -142,7 +142,7 @@ func (t *TargetClusters) Merge(b *TargetClusters) {
 		for feed, bReplicas := range b.Replicas {
 			if len(bReplicas) != 0 {
 				if len(t.Replicas[feed]) == 0 {
-					t.Replicas[feed] = append(t.Replicas[feed], 0)
+					t.Replicas[feed] = make([]int32, len(b.Replicas[feed]))
 				}
 				t.Replicas[feed][ti] += bReplicas[bi]
 			}

--- a/pkg/scheduler/framework/interfaces/types_test.go
+++ b/pkg/scheduler/framework/interfaces/types_test.go
@@ -138,6 +138,23 @@ func TestTargetClusters_Merge(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unsorted cluster",
+			b: &TargetClusters{
+				BindingClusters: []string{"c1", "c3", "c2"},
+				Replicas: map[string][]int32{
+					"f2": {1, 2, 0},
+				},
+			},
+			result: &TargetClusters{
+				BindingClusters: []string{"c1", "c2", "c3"},
+				Replicas: map[string][]int32{
+					"f1": {1, 2, 3},
+					"f2": {1, 0, 2},
+					"f3": {1, 0, 1},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t1 *testing.T) {


### PR DESCRIPTION
Signed-off-by: yinsenyan <yinsenyan@tencent.com>

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
bugfix
#### What this PR does / why we need it:
fix #487 bug
In `func (t *TargetClusters) Merge(b *TargetClusters)` , if t is 
```
  bindingClusters:
  - c1
  - c2
```
and b is 
```
  bindingClusters:
  - c2
  - c1
```
panic occuce at `t.Replicas[feed][ti] += bReplicas[bi]`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
