### PR TITLE
clean up legacy cluster lease

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -60,7 +60,6 @@ const (
 	// default number of threads
 	defaultThreadiness = 2
 
-	legacyLeaseName           = "self-cluster"
 	legacyClusterIDAnnotation = "legacy-cluster-id"
 
 	httpPrefix  = "http://"
@@ -398,45 +397,14 @@ func (agent *Agent) getClusterID(ctx context.Context, childClientSet kubernetes.
 		return "", err
 	}
 
-	// TODO: remove below legacy logic in release v0.17.0
-	// prefer to use legacy lease id
+	// for cluster registrations using clusternet-agent <= v0.14.0, please first upgrade to v0.15.0/v0.16.0, which
+	// migrates the legacy cluster id.
 	if legacyID, ok := lease.GetAnnotations()[legacyClusterIDAnnotation]; ok {
+		// fallback to use legacy lease id
 		return types.UID(legacyID), nil
 	}
-	// check whether legacy lease exists
-	leagcyLease, err := childClientSet.CoordinationV1().
-		Leases(agent.agentOptions.ControllerOptions.LeaderElection.ResourceNamespace).
-		Get(ctx, legacyLeaseName, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return lease.UID, nil
-		}
-		klog.Errorf("unable to retrieve %s/%s Lease object: %v",
-			agent.agentOptions.ControllerOptions.LeaderElection.ResourceNamespace,
-			legacyLeaseName, err)
-		return "", err
-	}
-	// migrate legacy lease
-	patchData, err := utils.GetPatchDataForLabelsAndAnnotations(nil, map[string]*string{
-		legacyClusterIDAnnotation: utilpointer.StringPtr(string(leagcyLease.UID)),
-	})
-	if err != nil {
-		klog.Errorf("failed to create patch data for legacy lease: %v", err)
-		return "", err
-	}
-	_, err = childClientSet.CoordinationV1().
-		Leases(agent.agentOptions.ControllerOptions.LeaderElection.ResourceNamespace).
-		Patch(ctx,
-			agent.agentOptions.ControllerOptions.LeaderElection.ResourceName,
-			types.MergePatchType,
-			patchData,
-			metav1.PatchOptions{})
-	if err != nil {
-		klog.Errorf("failed to migrate legacy lease %s/%s: %v",
-			agent.agentOptions.ControllerOptions.LeaderElection.ResourceNamespace, legacyLeaseName, err)
-		return "", err
-	}
-	return leagcyLease.UID, nil
+
+	return lease.UID, nil
 }
 
 func (agent *Agent) bootstrapClusterRegistrationIfNeeded(ctx context.Context) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/cleanup

#### What this PR does / why we need it:
A follow up of #586

Remove the migration logic when we've patched the annotation for the legacy cluster id.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
> We do hope the users will migrate `clusternet-agent` from v0.15.0/v0.16.0, which contains the legacy cluster-id migration.