### PR TITLE
replace deprecated func ioutil.ReadFile

### DIFF
--- a/pkg/scheduler/options/options.go
+++ b/pkg/scheduler/options/options.go
@@ -17,7 +17,7 @@ limitations under the License.
 package options
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
@@ -92,7 +92,7 @@ func (o *SchedulerOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func loadConfigFromFile(file string) (*apis.SchedulerConfiguration, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/enhancement

#### What this PR does / why we need it:
> Deprecated: As of Go 1.16, this function simply calls os.ReadFile.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
