### PR TITLE
record metrics data for health checks with feature gate ComponentSLIs

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -208,7 +208,11 @@ func (agent *Agent) Run(ctx context.Context) error {
 	}
 	// Start up the metrics and healthz server.
 	if agent.SecureServing != nil {
-		handler := controllermanagerapp.BuildHandlerChain(utils.NewHealthzAndMetricsHandler(agent.agentOptions.DebuggingOptions), nil, nil)
+		handler := controllermanagerapp.BuildHandlerChain(
+			utils.NewHealthzAndMetricsHandler("clusternet-agent", agent.agentOptions.DebuggingOptions),
+			nil,
+			nil,
+		)
 		if _, _, err = agent.SecureServing.Serve(handler, 0, ctx.Done()); err != nil {
 			// fail early for secure handlers, removing the old error loop from above
 			return fmt.Errorf("failed to start secure server: %v", err)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -200,7 +200,11 @@ func (sched *Scheduler) Run(ctx context.Context) error {
 	}
 	// Start up the metrics and healthz server.
 	if sched.SecureServing != nil {
-		handler := controllermanagerapp.BuildHandlerChain(utils.NewHealthzAndMetricsHandler(sched.schedulerOptions.DebuggingOptions), nil, nil)
+		handler := controllermanagerapp.BuildHandlerChain(
+			utils.NewHealthzAndMetricsHandler("clusternet-scheduler", sched.schedulerOptions.DebuggingOptions),
+			nil,
+			nil,
+		)
 		if _, _, err = sched.SecureServing.Serve(handler, 0, ctx.Done()); err != nil {
 			// fail early for secure handlers, removing the old error loop from above
 			return fmt.Errorf("failed to start secure server: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
Currently, our health check endpoints only output health information via `livez`, `readyz` and `healthz`. Generally you need to parse the return code to know if the component is healthy. We should also just record this data as a metric, so that we can parse it directly through a monitoring pipeline.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #609
Depends on #611

#### Special notes for your reviewer:
