### PR TITLE
add wait parameter on helm uninstall

### DIFF
--- a/manifests/crds/apps.clusternet.io_helmcharts.yaml
+++ b/manifests/crds/apps.clusternet.io_helmcharts.yaml
@@ -121,7 +121,7 @@ spec:
                 type: string
               wait:
                 description: Wait determines whether the wait operation should be
-                  performed after the upgrade is requested.
+                  performed after helm install, upgrade or uninstall is requested.
                 type: boolean
               waitForJob:
                 description: WaitForJobs determines whether the wait operation for

--- a/manifests/crds/apps.clusternet.io_helmreleases.yaml
+++ b/manifests/crds/apps.clusternet.io_helmreleases.yaml
@@ -129,7 +129,7 @@ spec:
                 type: string
               wait:
                 description: Wait determines whether the wait operation should be
-                  performed after the upgrade is requested.
+                  performed after helm install, upgrade or uninstall is requested.
                 type: boolean
               waitForJob:
                 description: WaitForJobs determines whether the wait operation for

--- a/pkg/apis/apps/v1alpha1/helm.go
+++ b/pkg/apis/apps/v1alpha1/helm.go
@@ -117,7 +117,7 @@ type HelmOptions struct {
 	// +kubebuilder:default=300
 	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty"`
 
-	// Wait determines whether the wait operation should be performed after the upgrade is requested.
+	// Wait determines whether the wait operation should be performed after helm install, upgrade or uninstall is requested.
 	//
 	// +optional
 	// +kubebuilder:validation:Type=boolean

--- a/pkg/utils/chart.go
+++ b/pkg/utils/chart.go
@@ -207,6 +207,9 @@ func UpgradeRelease(cfg *action.Configuration, hr *appsapi.HelmRelease,
 
 func UninstallRelease(cfg *action.Configuration, hr *appsapi.HelmRelease) error {
 	client := action.NewUninstall(cfg)
+	if hr.Spec.Wait != nil {
+		client.Wait = *hr.Spec.Wait
+	}
 	client.Timeout = time.Duration(hr.Spec.TimeoutSeconds) * time.Second
 	_, err := client.Run(getReleaseName(hr))
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does / why we need it:

sometimes when a helmrelease is deleting, resources like namespace is still terminating while the deplyer start `reconcile` and may cause conflict

so wait parameter should work on helm uninstall.
