### PR TITLE
Add new feature to rename cluster-hub to cluster-apiserver

### DIFF
--- a/cmd/clusternet-apiserver/apiserver.go
+++ b/cmd/clusternet-apiserver/apiserver.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/clusternet/clusternet/cmd/clusternet-apiserver/app"
+	"k8s.io/component-base/cli"
+	_ "k8s.io/component-base/logs/json/register" // for JSON log format registration
+
+	"github.com/clusternet/clusternet/pkg/utils"
+)
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+	command := app.NewAPIServerCommand(utils.GracefulStopWithContext())
+	code := cli.Run(command)
+	os.Exit(code)
+}

--- a/cmd/clusternet-apiserver/app/apiserver.go
+++ b/cmd/clusternet-apiserver/app/apiserver.go
@@ -1,0 +1,438 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	apiserver "github.com/clusternet/clusternet/pkg/hub/apiserver/shadow"
+
+	"github.com/clusternet/clusternet/cmd/clusternet-apiserver/app/options"
+	"github.com/clusternet/clusternet/pkg/controllers/misc/leasegc"
+	"github.com/clusternet/clusternet/pkg/features"
+	clusternet "github.com/clusternet/clusternet/pkg/generated/clientset/versioned"
+	informers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions"
+	_ "github.com/clusternet/clusternet/pkg/hub/metrics"
+	"github.com/clusternet/clusternet/pkg/known"
+	"github.com/clusternet/clusternet/pkg/utils"
+	"github.com/gorilla/mux"
+	"github.com/rancher/remotedialer"
+	coordinationapi "k8s.io/api/coordination/v1"
+	crdclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	kubeinformers "k8s.io/client-go/informers"
+	coordinationinformers "k8s.io/client-go/informers/coordination/v1"
+	"k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/controller-manager/pkg/clientbuilder"
+	"k8s.io/klog/v2"
+	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+	aggregatorinformers "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
+)
+
+const (
+	// peerLeasePrefix specifies the prefix name for clusternet-apiserver lease objects
+	peerLeasePrefix string = "clusternet-apiserver-peer"
+)
+
+// APIServer defines configuration for clusternet-apiserver
+type APIServer struct {
+	peerID  string
+	options *options.HubServerOptions
+
+	clusternetInformerFactory informers.SharedInformerFactory
+	kubeInformerFactory       kubeinformers.SharedInformerFactory
+	aggregatorInformerFactory aggregatorinformers.SharedInformerFactory
+
+	kubeClient       *kubernetes.Clientset
+	electionClient   *kubernetes.Clientset
+	clusternetClient *clusternet.Clientset
+	clientBuilder    clientbuilder.ControllerClientBuilder
+	socketConnection bool
+}
+
+// NewAPIServer returns a new APIServer.
+func NewAPIServer(opts *options.HubServerOptions) (*APIServer, error) {
+	socketConnection := utilfeature.DefaultFeatureGate.Enabled(features.SocketConnection)
+
+	config, err := utils.LoadsKubeConfig(&opts.ClientConnection)
+	if err != nil {
+		return nil, err
+	}
+
+	// creating the clientset
+	rootClientBuilder := clientbuilder.SimpleControllerClientBuilder{
+		ClientConfig: config,
+	}
+	kubeClient := kubernetes.NewForConfigOrDie(rootClientBuilder.ConfigOrDie("clusternet-apiserver-kube-client"))
+	clusternetClient := clusternet.NewForConfigOrDie(rootClientBuilder.ConfigOrDie("clusternet-apiserver-client"))
+	electionClient := kubernetes.NewForConfigOrDie(rootClientBuilder.ConfigOrDie("clusternet-apiserver-election-client"))
+
+	//deployer.broadcaster.StartStructuredLogging(5)
+	broadcaster := record.NewBroadcaster()
+	if kubeClient != nil {
+		klog.Infof("sending events to api server")
+		broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{
+			Interface: kubeClient.CoreV1().Events(""),
+		})
+	} else {
+		klog.Warningf("no api server defined - no events will be sent to API server.")
+	}
+
+	// creates the informer factory
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, known.DefaultResync)
+	clusternetInformerFactory := informers.NewSharedInformerFactory(clusternetClient, known.DefaultResync)
+	aggregatorInformerFactory := aggregatorinformers.NewSharedInformerFactory(aggregatorclient.
+		NewForConfigOrDie(rootClientBuilder.ConfigOrDie("clusternet-apiserver-kube-client")), known.DefaultResync)
+
+	hub := &APIServer{
+		peerID:                    utilrand.String(5),
+		options:                   opts,
+		kubeClient:                kubeClient,
+		electionClient:            electionClient,
+		clusternetClient:          clusternetClient,
+		clientBuilder:             rootClientBuilder,
+		clusternetInformerFactory: clusternetInformerFactory,
+		kubeInformerFactory:       kubeInformerFactory,
+		aggregatorInformerFactory: aggregatorInformerFactory,
+		socketConnection:          socketConnection,
+	}
+	return hub, nil
+}
+
+// Run starts a new APIServer given HubServerOptions
+func (hub *APIServer) Run(ctx context.Context) error {
+	klog.Info("starting clusternet-apiserver ...")
+	config, err := hub.options.Config()
+	if err != nil {
+		return err
+	}
+
+	completeConfig := config.Complete()
+	server, err := completeConfig.New(
+		hub.peerID,
+		hub.options.PeerToken,
+		hub.options.TunnelLogging,
+		hub.socketConnection,
+		hub.options.RecommendedOptions.Authentication.RequestHeader.ExtraHeaderPrefixes,
+		hub.clusternetInformerFactory,
+		hub.aggregatorInformerFactory)
+	if err != nil {
+		return err
+	}
+
+	curIdentity, err := utils.GenerateIdentity()
+	if err != nil {
+		return err
+	}
+
+	// create lease for peer
+	peerLease, err := createPeerLease(
+		peerInfo{
+			ID:       hub.peerID,
+			Identity: curIdentity,
+			Host:     hub.options.PeerAdvertiseAddress.String(),
+			Port:     hub.options.PeerPort,
+			Token:    hub.options.PeerToken,
+		},
+		hub.options.LeaderElection,
+		hub.electionClient,
+	)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("starting Clusternet informers ...")
+	// Start the informer factories to begin populating the informer caches
+	// Start method is non-blocking and runs all registered informers in a dedicated goroutine.
+	hub.kubeInformerFactory.Start(ctx.Done())
+	hub.clusternetInformerFactory.Start(ctx.Done())
+	hub.aggregatorInformerFactory.Start(ctx.Done())
+	config.GenericConfig.SharedInformerFactory.Start(ctx.Done())
+	// no need to start LoopbackSharedInformerFactory since we don't store anything in this apiserver
+	// hub.options.LoopbackSharedInformerFactory.Start(ctx.Done())
+
+	server.GenericAPIServer.AddPostStartHookOrDie("start-clusternet-apiserver-shadowapis",
+		func(postStartHookContext genericapiserver.PostStartHookContext) error {
+			if server.GenericAPIServer != nil && utilfeature.DefaultFeatureGate.Enabled(features.ShadowAPI) {
+				klog.Infof("install shadow apis...")
+				// waits for all started informers' cache got synced
+				hub.aggregatorInformerFactory.WaitForCacheSync(postStartHookContext.StopCh)
+
+				crdInformerFactory := crdinformers.NewSharedInformerFactory(
+					crdclientset.NewForConfigOrDie(hub.clientBuilder.ConfigOrDie("crd-shared-informers")),
+					5*time.Minute,
+				)
+
+				ss := apiserver.NewShadowAPIServer(server.GenericAPIServer,
+					completeConfig.GenericConfig.MaxRequestBodyBytes,
+					completeConfig.GenericConfig.MinRequestTimeout,
+					completeConfig.GenericConfig.AdmissionControl,
+					hub.kubeClient.RESTClient(),
+					hub.clusternetClient,
+					hub.clusternetInformerFactory.Apps().V1alpha1().Manifests().Lister(),
+					hub.aggregatorInformerFactory.Apiregistration().V1().APIServices().Lister(),
+					crdInformerFactory,
+					hub.options.ReservedNamespace)
+
+				crdInformerFactory.Start(postStartHookContext.StopCh)
+				return ss.InstallShadowAPIGroups(postStartHookContext.StopCh, hub.kubeClient.DiscoveryClient)
+			}
+
+			select {
+			case <-postStartHookContext.StopCh:
+			}
+
+			return nil
+		},
+	)
+
+	server.GenericAPIServer.AddPostStartHookOrDie("serving-peer-connections",
+		func(postStartHookContext genericapiserver.PostStartHookContext) error {
+			if !hub.options.LeaderElection.LeaderElect {
+				klog.Info("no need to serve peer connections")
+				return nil
+			}
+
+			serverCert := &hub.options.RecommendedOptions.SecureServing.ServerCert
+			certFile := serverCert.CertKey.CertFile
+			keyFile := serverCert.CertKey.KeyFile
+			if len(certFile) == 0 && len(keyFile) == 0 {
+				// use default self signed certs instead
+				certFile = path.Join(serverCert.CertDirectory, serverCert.PairName+".crt")
+				keyFile = path.Join(serverCert.CertDirectory, serverCert.PairName+".key")
+			}
+
+			peerServing := &http.Server{
+				Addr:    fmt.Sprintf("%s:%d", hub.options.RecommendedOptions.SecureServing.BindAddress, hub.options.PeerPort),
+				Handler: newPeerRouter(server.PeerDialer),
+			}
+			defer func() {
+				// use Close() to close all active socket connections
+				err = peerServing.Close()
+				if err != nil {
+					klog.Fatalf("failed to shutdown peer server: %v", err)
+				}
+			}()
+
+			go leasegc.NewLeaseGC(
+				hub.electionClient,
+				hub.options.LeaderElection.LeaseDuration.Duration,
+				hub.options.LeaderElection.ResourceNamespace,
+				func(lease *coordinationapi.Lease) bool {
+					return strings.HasPrefix(lease.Name, peerLeasePrefix)
+				},
+			).Run(ctx.Done())
+
+			go wait.UntilWithContext(ctx, func(ctx context.Context) {
+				peerLease.Run(ctx)
+			}, 0)
+
+			go func() {
+				klog.Info("starting serving peer connections")
+				if err = peerServing.ListenAndServeTLS(certFile, keyFile); err != http.ErrServerClosed {
+					klog.Fatalf("failed to serve peer connections: %v", err)
+					os.Exit(1)
+				}
+			}()
+
+			go refreshingPeers(hub.electionClient, hub.peerID, hub.options.LeaderElection.ResourceNamespace,
+				server.PeerDialer, postStartHookContext.StopCh)
+
+			select {
+			case <-postStartHookContext.StopCh:
+			}
+
+			return nil
+		},
+	)
+
+	return server.GenericAPIServer.PrepareRun().Run(ctx.Done())
+}
+
+func createPeerLease(peer peerInfo, leaderOption componentbaseconfig.LeaderElectionConfiguration,
+	clientset kubernetes.Interface) (*leaderelection.LeaderElector, error) {
+	peerLeaseName := fmt.Sprintf("%s-%s", peerLeasePrefix, peer.ID)
+
+	peerBytes, err := json.Marshal(peer)
+	if err != nil {
+		return nil, err
+	}
+
+	leaderElectionConfig := leaderelection.LeaderElectionConfig{
+		Lock: &resourcelock.LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{
+				Name:      peerLeaseName,
+				Namespace: leaderOption.ResourceNamespace,
+			},
+			Client: clientset.CoordinationV1(),
+			LockConfig: resourcelock.ResourceLockConfig{
+				Identity: string(peerBytes),
+			},
+		},
+		// IMPORTANT: you MUST ensure that any code you have that
+		// is protected by the lease must terminate **before**
+		// you call cancel. Otherwise, you could have a background
+		// loop still running and another process could
+		// get elected before your background loop finished, violating
+		// the stated goal of the lease.
+		ReleaseOnCancel: true,
+		LeaseDuration:   leaderOption.LeaseDuration.Duration,
+		RenewDeadline:   leaderOption.RenewDeadline.Duration,
+		RetryPeriod:     leaderOption.RetryPeriod.Duration,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaseCtx context.Context) {
+				// // no-op
+				<-leaseCtx.Done()
+			},
+			OnStoppedLeading: func() {
+				klog.Errorf("peer lease %s got lost", peerLeaseName)
+			},
+			OnNewLeader: func(identity string) {
+				// we're notified when new leader elected
+				if peer.Identity == identity {
+					// I just got the lock
+					return
+				}
+				// this should not happen
+				klog.Warningf("peer lease %s got unexpected leader %s", peerLeaseName, identity)
+			},
+		},
+	}
+
+	return leaderelection.NewLeaderElector(leaderElectionConfig)
+}
+
+func refreshingPeers(clientset kubernetes.Interface, selfID, leaseNamespace string, peerDialer *remotedialer.Server, stopCh <-chan struct{}) {
+	leaseInformer := coordinationinformers.NewFilteredLeaseInformer(
+		clientset,
+		leaseNamespace,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		nil)
+
+	leaseInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			lease := obj.(*coordinationapi.Lease)
+			if strings.HasPrefix(lease.Name, peerLeasePrefix) {
+				if fmt.Sprintf("%s-%s", peerLeasePrefix, selfID) == lease.Name {
+					return false
+				}
+				return true
+			}
+			return false
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				addPeer(peerDialer, obj.(*coordinationapi.Lease))
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				oldLease := oldObj.(*coordinationapi.Lease)
+				newLease := newObj.(*coordinationapi.Lease)
+
+				if oldLease.Spec.HolderIdentity != nil && newLease.Spec.HolderIdentity != nil &&
+					*oldLease.Spec.HolderIdentity == *newLease.Spec.HolderIdentity {
+					return
+				}
+
+				if newLease.Spec.HolderIdentity != nil {
+					addPeer(peerDialer, newLease)
+					return
+				}
+
+				// lease lost
+				removePeer(peerDialer, newLease)
+			},
+			DeleteFunc: func(obj interface{}) {
+				removePeer(peerDialer, obj.(*coordinationapi.Lease))
+			},
+		},
+	})
+
+	klog.Infof("refreshing peer connections ...")
+	leaseInformer.Run(stopCh)
+}
+
+func newPeerRouter(handler http.Handler) *mux.Router {
+	router := mux.NewRouter()
+	router.Handle("/connect", handler)
+	return router
+}
+
+func addPeer(peerDialer *remotedialer.Server, lease *coordinationapi.Lease) {
+	pi, err := getPeerInfo(lease)
+	if err != nil {
+		// TODO
+		return
+	}
+
+	if pi == nil {
+		return
+	}
+
+	url := fmt.Sprintf("wss://%s/connect", pi.Host)
+	if pi.Port > 0 {
+		url = fmt.Sprintf("wss://%s:%d/connect", pi.Host, pi.Port)
+	}
+	peerDialer.AddPeer(url, pi.ID, pi.Token)
+	klog.Infof("successfully add peer %s with url %s", pi.ID, url)
+}
+
+func removePeer(peerDialer *remotedialer.Server, lease *coordinationapi.Lease) {
+	peerID := strings.TrimPrefix(lease.Name, peerLeasePrefix+"-")
+	peerDialer.RemovePeer(peerID)
+	klog.Infof("successfully remove peer %s", peerID)
+}
+
+func getPeerInfo(lease *coordinationapi.Lease) (*peerInfo, error) {
+	if !strings.HasPrefix(lease.Name, peerLeasePrefix) {
+		return nil, nil
+	}
+
+	if lease.Spec.HolderIdentity == nil {
+		return &peerInfo{ID: strings.TrimPrefix(lease.Name, peerLeasePrefix+"-")}, nil
+	}
+
+	pi := &peerInfo{}
+	err := json.Unmarshal([]byte(*lease.Spec.HolderIdentity), pi)
+	return pi, err
+}
+
+type peerInfo struct {
+	Identity string `json:"identity,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Token    string `json:"token,omitempty"`
+}

--- a/cmd/clusternet-apiserver/app/app.go
+++ b/cmd/clusternet-apiserver/app/app.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/clusternet/clusternet/cmd/clusternet-apiserver/app/options"
+	"github.com/spf13/cobra"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/component-base/logs"
+	logsapi "k8s.io/component-base/logs/api/v1"
+	"k8s.io/component-base/term"
+	"k8s.io/klog/v2"
+
+	_ "github.com/clusternet/clusternet/pkg/features"
+	"github.com/clusternet/clusternet/pkg/version"
+)
+
+func init() {
+	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
+}
+
+var (
+	// the command name
+	cmdName = "clusternet-apiserver"
+)
+
+// NewAPIServerCommand creates a *cobra.Command object with default parameters
+func NewAPIServerCommand(ctx context.Context) *cobra.Command {
+	opts, err := options.NewHubServerOptions()
+	if err != nil {
+		klog.Fatalf("unable to initialize command options: %v", err)
+	}
+
+	cmd := &cobra.Command{
+		Use:  cmdName,
+		Long: `Running in parent cluster, provide REST operation support for shadow, proxy api for clusternet cli`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				if len(arg) > 0 {
+					return fmt.Errorf("%q does not take any arguments, got %q", cmd.CommandPath(), args)
+				}
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err = version.PrintAndExitIfRequested(cmdName); err != nil {
+				klog.Exit(err)
+			}
+
+			// Activate logging as soon as possible, after that
+			// show flags with the final logging configuration.
+			if err := logsapi.ValidateAndApply(opts.Logs, utilfeature.DefaultFeatureGate); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+			cliflag.PrintFlags(cmd.Flags())
+
+			if err = opts.Complete(); err != nil {
+				klog.Exit(err)
+			}
+			if err = opts.Validate(); err != nil {
+				klog.Exit(err)
+			}
+
+			apiServer, err2 := NewAPIServer(opts)
+			if err2 != nil {
+				klog.Exit(err2)
+			}
+			if err = apiServer.Run(ctx); err != nil {
+				klog.Exit(err)
+			}
+
+			// TODO: add logic
+		},
+	}
+
+	nfs := opts.Flags
+	version.AddVersionFlag(nfs.FlagSet("global"))
+	globalflag.AddGlobalFlags(nfs.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())
+	fs := cmd.Flags()
+	for _, f := range nfs.FlagSets {
+		fs.AddFlagSet(f)
+	}
+	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
+	cliflag.SetUsageAndHelpFunc(cmd, *nfs, cols)
+
+	return cmd
+}

--- a/cmd/clusternet-apiserver/app/options/options.go
+++ b/cmd/clusternet-apiserver/app/options/options.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2021 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/clusternet/clusternet/pkg/hub/apiserver"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
+	"k8s.io/apiserver/pkg/endpoints/openapi"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/version"
+	"k8s.io/client-go/rest"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
+
+	clientset "github.com/clusternet/clusternet/pkg/generated/clientset/versioned"
+	informers "github.com/clusternet/clusternet/pkg/generated/informers/externalversions"
+	clusternetopenapi "github.com/clusternet/clusternet/pkg/generated/openapi"
+	"github.com/clusternet/clusternet/pkg/known"
+	"github.com/clusternet/clusternet/pkg/utils"
+)
+
+const (
+	openAPITitle = "Clusternet"
+)
+
+// HubServerOptions contains state for master/api server
+type HubServerOptions struct {
+	// No tunnel logging by default
+	TunnelLogging bool
+
+	// Whether the anonymous access is allowed by the kube-apiserver,
+	// i.e. flag "--anonymous-auth=true" is set to kube-apiserver.
+	// If enabled, then the deployers in Clusternet will use anonymous when proxying requests to child clusters.
+	// If not, serviceaccount "clusternet-hub-proxy" will be used instead.
+	AnonymousAuthSupported bool
+
+	// default namespace to create Manifest in
+	// default to be "clusternet-reserved"
+	ReservedNamespace string
+
+	// threadiness of controller workers
+	// default to be 10
+	Threadiness int
+
+	RecommendedOptions *genericoptions.RecommendedOptions
+
+	LoopbackSharedInformerFactory informers.SharedInformerFactory
+
+	*utils.ControllerOptions
+
+	// advertise address to other peers
+	PeerAdvertiseAddress net.IP
+	// secure port used for communicating with peers
+	PeerPort int
+	// token used for authentication with peers
+	PeerToken string
+
+	ClusterAPIKubeconfig string
+
+	// Flags hold the parsed CLI flags.
+	Flags *cliflag.NamedFlagSets
+}
+
+// NewHubServerOptions returns a new HubServerOptions
+func NewHubServerOptions() (*HubServerOptions, error) {
+	controllerOpts, err := utils.NewControllerOptions("clusternet-hub", known.ClusternetSystemNamespace)
+	if err != nil {
+		return nil, err
+	}
+	controllerOpts.ClientConnection.QPS = rest.DefaultQPS * float32(10)
+	controllerOpts.ClientConnection.Burst = int32(rest.DefaultBurst * 10)
+
+	o := &HubServerOptions{
+		ControllerOptions:      controllerOpts,
+		RecommendedOptions:     genericoptions.NewRecommendedOptions("fake", nil),
+		AnonymousAuthSupported: true,
+		ReservedNamespace:      known.ClusternetReservedNamespace,
+		Threadiness:            known.DefaultThreadiness,
+		PeerPort:               8123,
+		PeerToken:              "Cheugy",
+	}
+	o.initFlags()
+	return o, nil
+}
+
+// Validate validates HubServerOptions
+func (o *HubServerOptions) Validate() error {
+	errors := []error{}
+	errors = append(errors, o.validateRecommendedOptions()...)
+	return utilerrors.NewAggregate(errors)
+}
+
+// Complete fills in fields required to have valid data
+func (o *HubServerOptions) Complete() error {
+	o.RecommendedOptions.CoreAPI.CoreAPIKubeconfigPath = o.ControllerOptions.ClientConnection.Kubeconfig
+
+	if o.PeerAdvertiseAddress == nil || o.PeerAdvertiseAddress.IsUnspecified() {
+		hostIP, err := o.RecommendedOptions.SecureServing.DefaultExternalAddress()
+		if err != nil {
+			return fmt.Errorf("unable to find suitable network address: '%v'. "+
+				"Try to set the PeerAdvertiseAddress directly or provide a valid BindAddress to fix this", err)
+		}
+		o.PeerAdvertiseAddress = hostIP
+	}
+
+	return nil
+}
+
+// Config returns config for the api server given HubServerOptions
+func (o *HubServerOptions) Config() (*apiserver.Config, error) {
+	// TODO have a "real" external address
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+	}
+
+	o.RecommendedOptions.ExtraAdmissionInitializers = func(c *genericapiserver.RecommendedConfig) ([]admission.PluginInitializer, error) {
+		client, err := clientset.NewForConfig(c.LoopbackClientConfig)
+		if err != nil {
+			return nil, err
+		}
+		informerFactory := informers.NewSharedInformerFactory(client, c.LoopbackClientConfig.Timeout)
+		o.LoopbackSharedInformerFactory = informerFactory
+		// TODO: add initializer
+		return []admission.PluginInitializer{}, nil
+	}
+
+	// remove NamespaceLifecycle admission plugin explicitly
+	o.RecommendedOptions.Admission.DisablePlugins = append(o.RecommendedOptions.Admission.DisablePlugins, lifecycle.PluginName)
+
+	serverConfig := genericapiserver.NewRecommendedConfig(apiserver.Codecs)
+	serverConfig.Config.RequestTimeout = time.Duration(40) * time.Second // override default 60s
+	serverConfig.LongRunningFunc = func(r *http.Request, requestInfo *apirequest.RequestInfo) bool {
+		if values := r.URL.Query()["watch"]; len(values) > 0 {
+			switch strings.ToLower(values[0]) {
+			case "true":
+				return true
+			default:
+				return false
+			}
+		}
+		return genericfilters.BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString())(r, requestInfo)
+	}
+	serverConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(clusternetopenapi.GetOpenAPIDefinitions, openapi.NewDefinitionNamer(apiserver.Scheme))
+	serverConfig.OpenAPIConfig.Info.Title = openAPITitle
+	serverConfig.OpenAPIConfig.Info.Version = version.Get().GitVersion
+
+	if err := o.recommendedOptionsApplyTo(serverConfig); err != nil {
+		return nil, err
+	}
+
+	config := &apiserver.Config{
+		GenericConfig: serverConfig,
+		ExtraConfig:   apiserver.ExtraConfig{},
+	}
+	return config, nil
+}
+
+// initFlags initializes flags by section name.
+func (o *HubServerOptions) initFlags() {
+	if o.Flags != nil {
+		return
+	}
+
+	fss := &cliflag.NamedFlagSets{}
+	o.addRecommendedOptionsFlags(fss)
+
+	// flags for clusternet-hub peer connections
+	peerfs := fss.FlagSet("peer connections")
+	peerfs.IPVar(&o.PeerAdvertiseAddress, "peer-advertise-address", o.PeerAdvertiseAddress, ""+
+		"The IP address on which to advertise the clusternet-hub to other peers in the cluster. This "+
+		"address must be reachable by the rest of the peers. If blank, the --bind-address "+
+		"will be used. If --bind-address is unspecified, the host's default interface will "+
+		"be used.")
+	peerfs.IntVar(&o.PeerPort, "peer-port", o.PeerPort, "The port on which to serve HTTPS for communicating with peers.")
+	peerfs.StringVar(&o.PeerToken, "peer-token", o.PeerToken, "The token for authentication with peers with peers.")
+
+	// flags for leader election and client connection
+	o.ControllerOptions.AddFlagSets(fss)
+
+	miscfs := fss.FlagSet("misc")
+	miscfs.BoolVar(&o.TunnelLogging, "enable-tunnel-logging", o.TunnelLogging, "Enable tunnel logging")
+	miscfs.BoolVar(&o.AnonymousAuthSupported, "anonymous-auth-supported", o.AnonymousAuthSupported, "Whether the anonymous access is allowed by the 'core' kubernetes server")
+	miscfs.StringVar(&o.ReservedNamespace, "reserved-namespace", o.ReservedNamespace, "The default namespace to create Manifest in")
+	miscfs.IntVar(&o.Threadiness, "threadiness", o.Threadiness, "The number of threads to use for controller workers")
+	miscfs.StringVar(&o.ClusterAPIKubeconfig, "cluster-api-kubeconfig", o.ClusterAPIKubeconfig, "Path to a kubeconfig file pointing at the management cluster for cluster-api.")
+
+	utilfeature.DefaultMutableFeatureGate.AddFlag(fss.FlagSet("feature gate"))
+
+	o.Flags = fss
+}
+
+func (o *HubServerOptions) addRecommendedOptionsFlags(nfs *cliflag.NamedFlagSets) {
+	// Copied from k8s.io/apiserver/pkg/server/options/recommended.go
+	// and remove unused flags
+
+	o.RecommendedOptions.SecureServing.AddFlags(nfs.FlagSet("secure serving"))
+	o.RecommendedOptions.Authentication.AddFlags(nfs.FlagSet("authentication"))
+	o.RecommendedOptions.Authorization.AddFlags(nfs.FlagSet("authorization"))
+	o.RecommendedOptions.Audit.LogOptions.AddFlags(nfs.FlagSet("audit"))
+	o.RecommendedOptions.Features.AddFlags(nfs.FlagSet("profiling"))
+	// flag "kubeconfig" has been declared in o.ControllerOptions
+	//o.RecommendedOptions.CoreAPI.AddFlags(fs) // --kubeconfig flag
+}
+
+func (o *HubServerOptions) validateRecommendedOptions() []error {
+	// Copied from k8s.io/apiserver/pkg/server/options/recommended.go
+	// and remove unused Validate
+
+	errors := []error{}
+	errors = append(errors, o.RecommendedOptions.SecureServing.Validate()...)
+	errors = append(errors, o.RecommendedOptions.Authentication.Validate()...)
+	errors = append(errors, o.RecommendedOptions.Authorization.Validate()...)
+	errors = append(errors, o.RecommendedOptions.Audit.LogOptions.Validate()...)
+	errors = append(errors, o.RecommendedOptions.Features.Validate()...)
+	errors = append(errors, o.RecommendedOptions.CoreAPI.Validate()...)
+	return errors
+}
+
+func (o *HubServerOptions) recommendedOptionsApplyTo(config *genericapiserver.RecommendedConfig) error {
+	// Copied from k8s.io/apiserver/pkg/server/options/recommended.go
+	// and remove unused ApplyTo
+
+	if err := o.RecommendedOptions.SecureServing.ApplyTo(&config.Config.SecureServing, &config.Config.LoopbackClientConfig); err != nil {
+		return err
+	}
+	if err := o.RecommendedOptions.Authentication.ApplyTo(&config.Config.Authentication, config.SecureServing, config.OpenAPIConfig); err != nil {
+		return err
+	}
+	if err := o.RecommendedOptions.Authorization.ApplyTo(&config.Config.Authorization); err != nil {
+		return err
+	}
+	if err := o.RecommendedOptions.Audit.ApplyTo(&config.Config); err != nil {
+		return err
+	}
+	if err := o.RecommendedOptions.Features.ApplyTo(&config.Config); err != nil {
+		return err
+	}
+	if err := o.RecommendedOptions.CoreAPI.ApplyTo(config); err != nil {
+		return err
+	}
+	if initializers, err := o.RecommendedOptions.ExtraAdmissionInitializers(config); err != nil {
+		return err
+	} else if err := o.RecommendedOptions.Admission.ApplyTo(&config.Config, config.SharedInformerFactory, config.ClientConfig, o.RecommendedOptions.FeatureGate, initializers...); err != nil {
+		return err
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.APIPriorityAndFairness) {
+		if config.ClientConfig != nil {
+			config.FlowControl = utilflowcontrol.New(
+				config.SharedInformerFactory,
+				kubernetes.NewForConfigOrDie(config.ClientConfig).FlowcontrolV1beta2(),
+				config.MaxRequestsInFlight+config.MaxMutatingRequestsInFlight,
+				config.RequestTimeout/4,
+			)
+		} else {
+			klog.Warningf("Neither kubeconfig is provided nor service-account is mounted, so APIPriorityAndFairness will be disabled")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

A follow-up of #638

before the refactoring, clusternet-hub contains apiserver, controller capability, so it is ok to use clusternet-hub. but now apiserver, controller has been split out separately, apiserver called clusternet-hub is not quite appropriate.

I think we need to redefine the concept, such as hub, agent represents the role of the cluster in clusternet, hub cluster  will contain apiserver, controller, scheduler components.

somethings todo:

- [ ] 1. adjust the deployment scripts: helmchart, local-running.sh
- [ ] 2. adjust the design documentation: concept map and examples on the official website
- [ ] 3. adjust the code directory: for example, under the pkg mainly includes apis, apiserver, scheduler, controller, agent...
- [ ] ...

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
xref #590 

#### Special notes for your reviewer:
