### PR TITLE
use namespaced name of Subscription for new Bases

### DIFF
--- a/pkg/hub/deployer/deployer.go
+++ b/pkg/hub/deployer/deployer.go
@@ -359,7 +359,7 @@ func (deployer *Deployer) populateBasesAndLocalizations(sub *appsapi.Subscriptio
 
 		baseTemplate := &appsapi.Base{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      sub.Name,
+				Name:      fmt.Sprintf("%s-%s", sub.Name, sub.Namespace),
 				Namespace: namespace,
 				Labels: map[string]string{
 					known.ObjectCreatedByLabel: known.ClusternetHubName,


### PR DESCRIPTION
### What type of PR is this?
bugfix
### What this PR does / why we need it:
Solve the problem described in the issue #641 .
### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #641 

### Special notes for your reviewer:
Maybe add an 8-digit random string after base.name is a better option, bug add namespace helps identify which subscription base belongs to and is relatively easy to implement, so we'll fix the issue like this for now