### PR TITLE
migrate workloads from not-ready clusters to healthy spare clusters

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -100,6 +100,13 @@ const (
 	// alpha: v0.15.0
 	// Setting on clusternet-controller-manager and clusternet-agent side.
 	MultiClusterService featuregate.Feature = "MultiClusterService"
+
+	// FailOver will migrate workloads from not-ready clusters to healthy spare clusters.
+	//
+	// owner: @dixudx
+	// alpha: v0.16.0
+	// Setting on clusternet-scheduler side.
+	FailOver featuregate.Feature = "FailOver"
 )
 
 func init() {
@@ -119,4 +126,5 @@ var defaultClusternetFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	FeedInventory:       {Default: false, PreRelease: featuregate.Alpha, LockToDefault: false},
 	Predictor:           {Default: false, PreRelease: featuregate.Alpha, LockToDefault: false},
 	MultiClusterService: {Default: false, PreRelease: featuregate.Alpha, LockToDefault: false},
+	FailOver:            {Default: false, PreRelease: featuregate.Alpha, LockToDefault: false},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
Add a feature gate to migrate workloads from not-ready clusters to healthy spare clusters

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
depends on #673 

#### Special notes for your reviewer:
