### PR TITLE
user-defined prefixes for label aggregation

### DIFF
--- a/pkg/agent/options/cluster_reg_options.go
+++ b/pkg/agent/options/cluster_reg_options.go
@@ -31,6 +31,7 @@ import (
 
 	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
 	"github.com/clusternet/clusternet/pkg/features"
+	"github.com/clusternet/clusternet/pkg/known"
 )
 
 var validateClusterNameRegex = regexp.MustCompile(nameFmt)
@@ -67,6 +68,9 @@ type ClusterRegistrationOptions struct {
 	// e.g LabelAggregateThreshold 0.8  means 80% of work nodes in child clusters labels in common will be aggregated to parent.
 	LabelAggregateThreshold float32
 
+	// LabelAggregatePrefix  specifies the prefix of node label which can be aggregate
+	LabelAggregatePrefix []string
+
 	// TODO: check ca hash
 }
 
@@ -79,6 +83,7 @@ func NewClusterRegistrationOptions() *ClusterRegistrationOptions {
 		ClusterStatusReportFrequency:  metav1.Duration{Duration: DefaultClusterStatusReportFrequency},
 		ClusterStatusCollectFrequency: metav1.Duration{Duration: DefaultClusterStatusCollectFrequency},
 		LabelAggregateThreshold:       0.8,
+		LabelAggregatePrefix:          []string{known.NodeLabelsKeyPrefix},
 	}
 }
 
@@ -109,6 +114,8 @@ func (opts *ClusterRegistrationOptions) AddFlagSets(fss *cliflag.NamedFlagSets) 
 		"Specify the labels for the child cluster, split by `,`")
 	mgmtfs.Float32Var(&opts.LabelAggregateThreshold, LabelAggregateThreshold, opts.LabelAggregateThreshold,
 		"Specifies the threshold of common labels in child cluster nodes should be aggregated to parent")
+	mgmtfs.StringArrayVar(&opts.LabelAggregatePrefix, LabelAggregatePrefix, opts.LabelAggregatePrefix,
+		"Specifies the desired prefixes of node labels to be aggregated")
 
 	mfs := fss.FlagSet("cluster health status")
 	mfs.DurationVar(&opts.ClusterStatusReportFrequency.Duration, ClusterStatusReportFrequency, opts.ClusterStatusReportFrequency.Duration,

--- a/pkg/agent/options/constant.go
+++ b/pkg/agent/options/constant.go
@@ -67,6 +67,9 @@ const (
 
 	// LabelAggregateThreshold 0.8 means 80% of work nodes in child clusters labels in common will be aggregated to parent.
 	LabelAggregateThreshold = "labels-aggregate-threshold"
+
+	// LabelAggregatePrefix means prefix can be aggregate
+	LabelAggregatePrefix = "labels-aggregate-prefix"
 )
 
 // default values


### PR DESCRIPTION
#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
In old version , we hard code label prefix for aggregate.
We need aggregate label by custom in more cases.

#### Which issue(s) this PR fixes:
If there are multiple key-value pairs with same key whose occurrence ratio is greater than the threshold, we need to aggregate the key-value pairs that appear more times, not the last one.

#### Special notes for your reviewer:
