### PR TITLE
fix pruning obsolete feeds when running in pull mode

### DIFF
--- a/pkg/agent/deployer/deployer.go
+++ b/pkg/agent/deployer/deployer.go
@@ -94,10 +94,11 @@ func (d *Deployer) Run(
 
 	// make sure deployer gets initialized before we go next
 	appDeployerSecret := utils.GetDeployerCredentials(ctx, childKubeClientSet, d.systemNamespace, d.saTokenAutoGen)
-	if d.appPusherEnabled && d.syncMode != clusterapi.Pull {
-		klog.V(4).Infof("initializing deployer with sync mode %s", d.syncMode)
-		createDeployerCredentialsToParentCluster(ctx, parentClientSet, string(*clusterID), *dedicatedNamespace, d.childAPIServerURL, appDeployerSecret)
-	}
+
+	// creating credentials to parent cluster is also required in the pull mode,
+	// because the cleaning of redundant objects in the description is performed in the hub
+	klog.V(4).Infof("initializing deployer with sync mode %s", d.syncMode)
+	createDeployerCredentialsToParentCluster(ctx, parentClientSet, string(*clusterID), *dedicatedNamespace, d.childAPIServerURL, appDeployerSecret)
 
 	// setup broadcaster and event recorder in parent cluster
 	broadcaster := record.NewBroadcaster()

--- a/pkg/controllermanager/deployer/deployer.go
+++ b/pkg/controllermanager/deployer/deployer.go
@@ -892,10 +892,11 @@ func (deployer *Deployer) syncDescriptions(base *appsapi.Base, desc *appsapi.Des
 			// Here we only need to focus on generic deployer.
 			pruneCtx, cancel := context.WithCancel(context.TODO())
 			go wait.JitterUntilWithContext(pruneCtx, func(ctx context.Context) {
-				if err := deployer.genericDeployer.PruneFeedsInDescription(ctx, curDesc.DeepCopy(), desc.DeepCopy()); err == nil {
-					cancel()
+				if err := deployer.genericDeployer.PruneFeedsInDescription(ctx, curDesc.DeepCopy(), desc.DeepCopy()); err != nil {
+					klog.Warningf("Prune feed in description %s failed: %v", klog.KObj(curDesc), err)
 					return
 				}
+				cancel()
 			}, known.DefaultRetryPeriod, 0.3, true)
 
 			curDescCopy := curDesc.DeepCopy()


### PR DESCRIPTION
#### What type of PR is this?
kind/bug

fix feed leak when agent is in pull mode

#### What this PR does / why we need it:

* feed may leak when agent is in pull mode
* there is no warning or error log when hub failed to prune feeds for description

#### Which issue(s) this PR fixes:

Fixes #710

#### Special notes for your reviewer:
