### PR TITLE
fix the merging algorithm when the previous target cluster is empty

### DIFF
--- a/pkg/scheduler/framework/interfaces/types.go
+++ b/pkg/scheduler/framework/interfaces/types.go
@@ -147,6 +147,7 @@ func (t *TargetClusters) MergeOneFeed(b *TargetClusters) {
 			} else {
 				// new cluster, add cluster to t binding cluster
 				t.BindingClusters = append(t.BindingClusters, cluster)
+				m[cluster] = len(t.BindingClusters) - 1
 				// add 0 to exist feed but new cluster, if feed is nil, skip it
 				for f := range t.Replicas {
 					if f != feed {

--- a/pkg/scheduler/framework/interfaces/types_test.go
+++ b/pkg/scheduler/framework/interfaces/types_test.go
@@ -177,7 +177,7 @@ func TestTargetClusters_Merge(t *testing.T) {
 	}
 }
 
-func TestTargetCLusters_MergeOneFeed(t *testing.T) {
+func TestTargetClusters_MergeOneFeed(t *testing.T) {
 	template := &TargetClusters{
 		BindingClusters: []string{"c1", "c2", "c3"},
 		Replicas: map[string][]int32{
@@ -285,4 +285,31 @@ func TestTargetCLusters_MergeOneFeed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTargetClusters_MergeOneFeed_TargetClusterEmpty(t *testing.T) {
+	template := &TargetClusters{
+		BindingClusters: nil,
+		Replicas:        nil,
+	}
+	b := &TargetClusters{
+		BindingClusters: []string{"c2", "c3"},
+		Replicas: map[string][]int32{
+			"f1": {1, 2},
+			"f3": {1, 0},
+		},
+	}
+	result := &TargetClusters{
+		BindingClusters: []string{"c2", "c3"},
+		Replicas: map[string][]int32{
+			"f1": {1, 2},
+			"f3": {1, 0},
+		},
+	}
+	t.Run("panic", func(t *testing.T) {
+		template.MergeOneFeed(b)
+		if !reflect.DeepEqual(template, result) {
+			t.Errorf("MergeOneFeed() \ngot = %v\nwant= %v", result, template)
+		}
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:
Fix the bug that the merge of scheduling results does not meet expectations when the previous target cluster is empty

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #712 

#### Special notes for your reviewer:
