### PR TITLE
remove healthCheckNodePort field when create a loadbalance service

### DIFF
--- a/pkg/hub/registry/shadow/template/trimmer.go
+++ b/pkg/hub/registry/shadow/template/trimmer.go
@@ -48,6 +48,11 @@ func trimCoreService(result *unstructured.Unstructured) {
 
 	switch corev1.ServiceType(serviceType) {
 	case corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer:
+		// corev1.Service will allocate health check node port automatically for services with type LoadBalance
+		_, found2, _ := unstructured.NestedInt64(result.Object, "spec", "healthCheckNodePort")
+		if found2 {
+			unstructured.RemoveNestedField(result.Object, "spec", "healthCheckNodePort")
+		}
 		// corev1.Service will init node ports when creating NodePort or LoadBalancer
 		items, found2, err2 := unstructured.NestedSlice(result.Object, "spec", "ports")
 		if !found2 || err2 != nil {

--- a/pkg/hub/registry/shadow/template/trimmer_test.go
+++ b/pkg/hub/registry/shadow/template/trimmer_test.go
@@ -201,6 +201,91 @@ func TestTrimCoreService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Service HealthCheckNodePort",
+			resultRaw: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]interface{}{
+						"creationTimestamp": "2021-11-01T08:12:43Z",
+						"labels": map[string]string{
+							"clusternet.io/created-by": "clusternet-hub",
+						},
+						"name":            "my-test-healthchecknodeport-svc",
+						"namespace":       "nginx-test",
+						"resourceVersion": "4457294",
+						"selfLink":        "test-link",
+						"uid":             "28f5ae38-9eea-431c-918b-68ffdf263c24",
+					},
+					"spec": map[string]interface{}{
+						"clusterIP":             "None",
+						"externalTrafficPolicy": "Local",
+						"ipFamilies": []string{
+							"IPv4",
+						},
+						"ipFamilyPolicy":      "SingleStack",
+						"healthCheckNodePort": int64(32770),
+						"ports": []interface{}{
+							map[string]interface{}{
+								"name":       "tcp-80-80",
+								"port":       int64(80),
+								"protocol":   "TCP",
+								"targetPort": int64(80),
+							},
+							map[string]interface{}{
+								"name":       "tcp-443-443",
+								"port":       int64(443),
+								"protocol":   "TCP",
+								"targetPort": int64(443),
+							},
+						},
+						"sessionAffinity": "None",
+						"type":            "LoadBalancer",
+					},
+					"status": map[string]interface{}{},
+				},
+			},
+			resultDesired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]interface{}{
+						"labels": map[string]string{
+							"clusternet.io/created-by": "clusternet-hub",
+						},
+						"name":      "my-test-healthchecknodeport-svc",
+						"namespace": "nginx-test",
+						"uid":       "28f5ae38-9eea-431c-918b-68ffdf263c24",
+					},
+					"spec": map[string]interface{}{
+						"clusterIP":             "None",
+						"externalTrafficPolicy": "Local",
+						"ipFamilies": []string{
+							"IPv4",
+						},
+						"ipFamilyPolicy": "SingleStack",
+						"ports": []interface{}{
+							map[string]interface{}{
+								"name":       "tcp-80-80",
+								"port":       int64(80),
+								"protocol":   "TCP",
+								"targetPort": int64(80),
+							},
+							map[string]interface{}{
+								"name":       "tcp-443-443",
+								"port":       int64(443),
+								"protocol":   "TCP",
+								"targetPort": int64(443),
+							},
+						},
+						"sessionAffinity": "None",
+						"type":            "LoadBalancer",
+					},
+					"status": map[string]interface{}{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

#### What type of PR is this?
kind/bug

#### What this PR does / why we need it:
corev1.Service will allocate health check node port automatically for services with type LoadBalance, so remove healthCheckNodePort field in clusternet hub

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
