### PR TITLE
ignore checking AppPusher for helm charts

### DIFF
--- a/pkg/controllermanager/deployer/helm/helm.go
+++ b/pkg/controllermanager/deployer/helm/helm.go
@@ -216,23 +216,7 @@ func (deployer *Deployer) handleDescription(descCopy *appsapi.Description) error
 		return err
 	}
 
-	// check if mcls object exists and ignore checking AppPusher for helm charts
-	labelSet := labels.Set{}
-	if len(descCopy.Labels[known.ClusterIDLabel]) > 0 {
-		labelSet[known.ClusterIDLabel] = descCopy.Labels[known.ClusterIDLabel]
-	}
-	mcls, err := deployer.clusterLister.ManagedClusters(descCopy.Namespace).List(
-		labels.SelectorFromSet(labelSet))
-	if err != nil {
-		return err
-	}
-	if mcls == nil {
-		deployer.recorder.Event(descCopy, corev1.EventTypeWarning, "ManagedClusterNotFound",
-			fmt.Sprintf("can not find a ManagedCluster with uid=%s in current namespace", descCopy.Labels[known.ClusterIDLabel]))
-		return fmt.Errorf("failed to find a ManagedCluster declaration in namespace %s", descCopy.Namespace)
-	}
-
-	if err = deployer.populateHelmRelease(descCopy); err != nil {
+	if err := deployer.populateHelmRelease(descCopy); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
bugfix for HelmChart resources deployment when clusternet-agent sets AppPusher=false

#### Which issue(s) this PR fixes:
Fixes #735

#### Special notes for your reviewer:
