### PR TITLE
Add mcs-related resource syncer role and rolebinding

### DIFF
--- a/deploy/hub/clusternet_hub_deployment.yaml
+++ b/deploy/hub/clusternet_hub_deployment.yaml
@@ -10,6 +10,12 @@ metadata:
   name: clusternet-system
 
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusternet-mcs
+
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/deploy/hub/clusternet_hub_rbac.yaml
+++ b/deploy/hub/clusternet_hub_rbac.yaml
@@ -10,3 +10,13 @@ subjects:
   - kind: ServiceAccount
     name: clusternet-hub
     namespace: clusternet-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: clusternet-mcs
+  name: mcs-syncer
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["*"]

--- a/pkg/controllermanager/approver/constant.go
+++ b/pkg/controllermanager/approver/constant.go
@@ -22,4 +22,9 @@ const (
 	ManagedClusterRole = "clusternet-managedcluster-role"
 	// SocketsClusterRoleNamePrefix is the prefix name of Sockets clusterrole
 	SocketsClusterRoleNamePrefix = "clusternet-"
+
+	// MultiClusterServiceSyncerRole is the default role  to syncer mcs-related resources
+	MultiClusterServiceSyncerRole = "mcs-syncer"
+	// MultiClusterServiceNamespace is the default namespace to store mcs-related resources
+	MultiClusterServiceNamespace = "clusternet-mcs"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Feature add.

#### What this PR does / why we need it:
Add a namespace and a  role to synce mcs-related resources, like endpointslices accross clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:
It fit for new joined clusters, may be difficult to handle clusters that have been joined into parent before.
