### PR TITLE
improve performance of controller

### DIFF
--- a/pkg/controllermanager/deployer/deployer.go
+++ b/pkg/controllermanager/deployer/deployer.go
@@ -1112,7 +1112,6 @@ func (deployer *Deployer) resyncBase(baseUIDs ...string) error {
 
 		go func() {
 			defer wg.Done()
-			// here the length should always be 1
 			if err = deployer.populateDescriptions(base); err != nil {
 				errCh <- err
 			}

--- a/pkg/controllermanager/deployer/deployer.go
+++ b/pkg/controllermanager/deployer/deployer.go
@@ -275,11 +275,7 @@ func (deployer *Deployer) Run(workers int, ctx context.Context) {
 func (deployer *Deployer) handleSubscription(subCopy *appsapi.Subscription) error {
 	klog.V(5).Infof("handle Subscription %s", klog.KObj(subCopy))
 	if subCopy.DeletionTimestamp != nil {
-		bases, err := deployer.baseLister.List(labels.SelectorFromSet(labels.Set{
-			known.ConfigKindLabel:      subscriptionKind.Kind,
-			known.ConfigNamespaceLabel: subCopy.Namespace,
-			known.ConfigUIDLabel:       string(subCopy.UID),
-		}))
+		bases, err := deployer.baseController.FindBaseBySubUID(string(subCopy.UID))
 		if err != nil {
 			return err
 		}
@@ -327,13 +323,9 @@ func (deployer *Deployer) handleSubscription(subCopy *appsapi.Subscription) erro
 // Localization(s) will be populated as well for dividing scheduling.
 func (deployer *Deployer) populateBasesAndLocalizations(sub *appsapi.Subscription) error {
 	klog.V(5).Infof("Start populating bases and localizations for subscription %s/%s ", sub.Namespace, sub.Name)
-	allExistingBases, listErr := deployer.baseLister.List(labels.SelectorFromSet(labels.Set{
-		known.ConfigKindLabel:      subscriptionKind.Kind,
-		known.ConfigNamespaceLabel: sub.Namespace,
-		known.ConfigUIDLabel:       string(sub.UID),
-	}))
-	if listErr != nil {
-		return listErr
+	allExistingBases, err := deployer.baseController.FindBaseBySubUID(string(sub.UID))
+	if err != nil {
+		return err
 	}
 	// Bases to be deleted
 	basesToBeDeleted := sets.String{}
@@ -344,8 +336,8 @@ func (deployer *Deployer) populateBasesAndLocalizations(sub *appsapi.Subscriptio
 	var allErrs []error
 	for idx, namespacedName := range sub.Status.BindingClusters {
 		// Convert the namespacedName/name string into a distinct namespacedName and name
-		namespace, _, err := cache.SplitMetaNamespaceKey(namespacedName)
-		if err != nil {
+		namespace, _, err2 := cache.SplitMetaNamespaceKey(namespacedName)
+		if err2 != nil {
 			allErrs = append(allErrs, fmt.Errorf("invalid resource key: %s", namespacedName))
 			continue
 		}
@@ -355,7 +347,7 @@ func (deployer *Deployer) populateBasesAndLocalizations(sub *appsapi.Subscriptio
 			if apierrors.IsNotFound(err2) {
 				continue
 			}
-			return fmt.Errorf("failed to populate Bases for Subscription %s: %v", klog.KObj(sub), err)
+			return fmt.Errorf("failed to populate Bases for Subscription %s: %v", klog.KObj(sub), err2)
 		}
 		var basesInCurrentNamespace []*appsapi.Base
 		for _, b := range allExistingBases {
@@ -415,10 +407,10 @@ func (deployer *Deployer) populateBasesAndLocalizations(sub *appsapi.Subscriptio
 			klog.Infof("reuse latest existed Base %s for Subscription %s", klog.KObj(baseTemplate), klog.KObj(sub))
 		}
 
-		base, err := deployer.syncBase(sub, baseTemplate)
-		if err != nil {
-			allErrs = append(allErrs, err)
-			msg := fmt.Sprintf("Failed to sync Base %s: %v", klog.KObj(baseTemplate), err)
+		base, err2 := deployer.syncBase(sub, baseTemplate)
+		if err2 != nil {
+			allErrs = append(allErrs, err2)
+			msg := fmt.Sprintf("Failed to sync Base %s: %v", klog.KObj(baseTemplate), err2)
 			klog.ErrorDepth(5, msg)
 			deployer.recorder.Event(sub, corev1.EventTypeWarning, "FailedSyncingBase", msg)
 			continue
@@ -433,7 +425,7 @@ func (deployer *Deployer) populateBasesAndLocalizations(sub *appsapi.Subscriptio
 	}
 
 	for key := range basesToBeDeleted {
-		err := deployer.deleteBase(context.TODO(), key)
+		err = deployer.deleteBase(context.TODO(), key)
 		if err != nil {
 			allErrs = append(allErrs, err)
 		}
@@ -702,7 +694,7 @@ func (deployer *Deployer) deleteLocalization(ctx context.Context, namespacedKey 
 func (deployer *Deployer) handleBase(baseCopy *appsapi.Base) error {
 	klog.V(5).Infof("handle Base %s", klog.KObj(baseCopy))
 	if baseCopy.DeletionTimestamp != nil {
-		descs, err := deployer.descLister.List(labels.SelectorFromSet(labels.Set{
+		descs, err := deployer.descLister.Descriptions(baseCopy.Namespace).List(labels.SelectorFromSet(labels.Set{
 			known.ConfigKindLabel:      baseKind.Kind,
 			known.ConfigNameLabel:      baseCopy.Name,
 			known.ConfigNamespaceLabel: baseCopy.Namespace,
@@ -813,7 +805,7 @@ func (deployer *Deployer) populateDescriptions(base *appsapi.Base) error {
 		return err
 	}
 
-	allExistingDescriptions, err := deployer.descLister.List(labels.SelectorFromSet(labels.Set{
+	allExistingDescriptions, err := deployer.descLister.Descriptions(base.Namespace).List(labels.SelectorFromSet(labels.Set{
 		known.ConfigKindLabel:      baseKind.Kind,
 		known.ConfigNamespaceLabel: base.Namespace,
 		known.ConfigUIDLabel:       string(base.UID),
@@ -1111,21 +1103,17 @@ func (deployer *Deployer) resyncBase(baseUIDs ...string) error {
 	wg.Add(len(baseUIDs))
 	errCh := make(chan error, len(baseUIDs))
 	for _, baseuid := range baseUIDs {
-		bases, err := deployer.baseLister.List(labels.SelectorFromSet(labels.Set{
-			baseuid: baseKind.Kind,
-		}))
-
+		base, err := deployer.baseController.FindBaseByUID(baseuid)
 		if err != nil {
-			return err
+			wg.Done()
+			klog.Warning(fmt.Sprintf("failed to resyncBase %s: %v", baseuid, err))
+			continue
 		}
 
 		go func() {
 			defer wg.Done()
-			if len(bases) == 0 {
-				return
-			}
 			// here the length should always be 1
-			if err = deployer.populateDescriptions(bases[0]); err != nil {
+			if err = deployer.populateDescriptions(base); err != nil {
 				errCh <- err
 			}
 		}()

--- a/pkg/controllermanager/deployer/helm/helm.go
+++ b/pkg/controllermanager/deployer/helm/helm.go
@@ -229,7 +229,7 @@ func (deployer *Deployer) handleDescription(descCopy *appsapi.Description) error
 }
 
 func (deployer *Deployer) populateHelmRelease(desc *appsapi.Description) error {
-	allExistingHelmReleases, err := deployer.hrLister.List(labels.SelectorFromSet(labels.Set{
+	allExistingHelmReleases, err := deployer.hrLister.HelmReleases(desc.Namespace).List(labels.SelectorFromSet(labels.Set{
 		known.ConfigKindLabel:      desc.Kind,
 		known.ConfigNameLabel:      desc.Name,
 		known.ConfigNamespaceLabel: desc.Namespace,

--- a/pkg/known/constant.go
+++ b/pkg/known/constant.go
@@ -97,3 +97,8 @@ const (
 	// DefaultRandomIDLength is the default length for random id
 	DefaultRandomIDLength = 5
 )
+
+const (
+	IndexKeyForSubscriptionUID = "subUid"
+	IndexKeyForBaseUID         = "baseUid"
+)

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -933,3 +933,21 @@ func UpdateDescriptionStatus(desc *appsapi.Description, status *appsapi.Descript
 		return err2
 	})
 }
+
+func BaseUidIndexFunc(obj interface{}) ([]string, error) {
+	base := obj.(*appsapi.Base)
+	return []string{string(base.UID)}, nil
+}
+
+func BaseSubUidIndexFunc(obj interface{}) ([]string, error) {
+	base := obj.(*appsapi.Base)
+	if subUid, ok := base.Labels[known.ConfigSubscriptionUIDLabel]; ok {
+		return []string{subUid}, nil
+	}
+	return []string{""}, nil
+}
+
+func SubUidIndexFunc(obj interface{}) ([]string, error) {
+	sub := obj.(*appsapi.Subscription)
+	return []string{string(sub.UID)}, nil
+}

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -949,10 +949,10 @@ func BaseSubUidIndexFunc(obj interface{}) ([]string, error) {
 	}
 
 	subUid, ok := base.Labels[known.ConfigSubscriptionUIDLabel]
-	if ok {
-		return []string{subUid}, nil
+	if !ok {
+		return nil, fmt.Errorf("no subUid found for Base %#v", obj)
 	}
-	return []string{""}, nil
+	return []string{subUid}, nil
 }
 
 func SubUidIndexFunc(obj interface{}) ([]string, error) {

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -948,7 +948,8 @@ func BaseSubUidIndexFunc(obj interface{}) ([]string, error) {
 		return nil, fmt.Errorf("object is not a Base %#v", obj)
 	}
 
-	if subUid, ok := base.Labels[known.ConfigSubscriptionUIDLabel]; ok {
+	subUid, ok := base.Labels[known.ConfigSubscriptionUIDLabel]
+	if ok {
 		return []string{subUid}, nil
 	}
 	return []string{""}, nil

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -935,12 +935,19 @@ func UpdateDescriptionStatus(desc *appsapi.Description, status *appsapi.Descript
 }
 
 func BaseUidIndexFunc(obj interface{}) ([]string, error) {
-	base := obj.(*appsapi.Base)
+	base, ok := obj.(*appsapi.Base)
+	if !ok {
+		return nil, fmt.Errorf("object is not a Base %#v", obj)
+	}
 	return []string{string(base.UID)}, nil
 }
 
 func BaseSubUidIndexFunc(obj interface{}) ([]string, error) {
-	base := obj.(*appsapi.Base)
+	base, ok := obj.(*appsapi.Base)
+	if !ok {
+		return nil, fmt.Errorf("object is not a Base %#v", obj)
+	}
+
 	if subUid, ok := base.Labels[known.ConfigSubscriptionUIDLabel]; ok {
 		return []string{subUid}, nil
 	}
@@ -948,6 +955,9 @@ func BaseSubUidIndexFunc(obj interface{}) ([]string, error) {
 }
 
 func SubUidIndexFunc(obj interface{}) ([]string, error) {
-	sub := obj.(*appsapi.Subscription)
+	sub, ok := obj.(*appsapi.Subscription)
+	if !ok {
+		return nil, fmt.Errorf("object is not a Subscription %#v", obj)
+	}
 	return []string{string(sub.UID)}, nil
 }

--- a/pkg/utils/feed.go
+++ b/pkg/utils/feed.go
@@ -140,15 +140,11 @@ func FindObsoletedFeeds(oldFeeds []appsapi.Feed, newFeeds []appsapi.Feed) []apps
 func FindBasesFromUIDs(baseIndexer cache.Indexer, uids []string) []*appsapi.Base {
 	allBases := []*appsapi.Base{}
 	for _, uid := range uids {
-		if objs, err := baseIndexer.ByIndex("uid", uid); err != nil {
-			klog.ErrorDepth(5, err)
-			continue
+		objs, err := baseIndexer.ByIndex(known.IndexKeyForBaseUID, uid)
+		if err != nil || len(objs) == 0 {
+			klog.ErrorDepth(5, fmt.Errorf("find base by uid %s failed: %v %d", uid, err, len(objs)))
 		} else {
-			if len(objs) == 1 {
-				allBases = append(allBases, objs[0].(*appsapi.Base))
-			} else {
-				klog.ErrorDepth(5, fmt.Errorf("find base by uid %s failed", uid))
-			}
+			allBases = append(allBases, objs[0].(*appsapi.Base))
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
This PR is aimed at optimizing the performance of controller components in large-scale scenarios.

When there are many cr objects, the efficiency of index is much higher than that of list by selector, as shown in this performance test.
**Here's the case**:
```
func BenchmarkGetByList(b *testing.B) {
	for n := 0; n < b.N; n++ {
		if subs, err := subsLister.Subscriptions("clusternet-test").List(labels.SelectorFromSet(
			labels.Set{"6640f948-89af-4d1d-976d-08968895457d": "Subscription"})); err != nil || len(subs) != 1 {
			b.Fatalf("list fialed: %v %d", err, len(subs))
		}
	}
}

func BenchmarkGetByIndex(b *testing.B) {
	for n := 0; n < b.N; n++ {
		if objs, err := sInformer.GetIndexer().ByIndex("uid", "6640f948-89af-4d1d-976d-08968895457d"); err != nil || len(objs) != 1 {
			b.Fatalf("list fialed: %v %d", err, len(objs))
		}
	}
}
```
**Benchmark results**:
```
2023-11-01T14:49:23+08:00: list subscription
2023-11-01T14:49:23+08:00: total count of subs is 100000
goos: darwin
goarch: arm64
BenchmarkGetByList-10                 46          24414396 ns/op
BenchmarkGetByIndex-10          15271741                79.20 ns/op
```
When searching from a list of 100,000 cr objects, the efficiency of index is much higher than that of list.

#### What this PR does / why we need it:
This PR focuses on optimizing the base lookup process in the controller, which involves helmcharts, manifests, and subs processing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #753 

#### Special notes for your reviewer:
