### PR TITLE
Fix admit if some subscription spec field are updated

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -691,7 +691,7 @@ func admit(sub *appsapi.Subscription, finv *appsapi.FeedInventory) bool {
 	if sub.Spec.SchedulingStrategy == appsapi.ReplicaSchedulingStrategyType {
 		return true
 	}
-	specHashChanged := utils.HashSubscriptionSpec(&sub.Spec) == sub.Status.SpecHash
+	specHashChanged := utils.HashSubscriptionSpec(&sub.Spec) != sub.Status.SpecHash
 	feedChanged := isFeedChanged(sub, finv)
 	return specHashChanged || feedChanged
 }


### PR DESCRIPTION
#### What type of PR is this?
bugfix
#### What this PR does / why we need it:
If update subscription spec, such as `Spread` to `Binpack`.
