### PR TITLE
optimize/rewrite the logic and unit test of finding cluster service/pod ip range

### DIFF
--- a/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
+++ b/pkg/controllers/clusters/clusterstatus/clusterstatus_controller.go
@@ -320,7 +320,7 @@ func (c *Controller) discoverServiceCIDR() (string, error) {
 
 // discoverClusterCIDR returns the cluster CIDR for the cluster.
 func (c *Controller) discoverClusterCIDR() (string, error) {
-	return findPodIPRange(c.nodeLister, c.podLister)
+	return findPodIPRange(c.podLister)
 }
 
 // get node capacity and allocatable resource


### PR DESCRIPTION
#### What type of PR is this?

Fix or Optimize

#### What this PR does / why we need it:

According to the original logic, but fix some issues and optimize: 

1. Remove find pod ip range from pod's spec. The `node.spec.podCIDR` field is not the cluster pod ip range, but the node-assigned.
> `kubectl explain node.spec.podCIDR` shows:
> PodCIDR represents the pod IP range assigned to the node

2. Correct the label selector of kube-proxy from `component=kube-proxy` to `k8s-app=kube-proxy`

3. Similar to `findPodIPRange` function, add the redundant finding from kube-controller-manager.

4. rewrite the unit test for testing all logic and optimize the finding parameter of `labels.Selector`. 
