### PR TITLE
pass the finding pod error to caller instead of ignoring

### DIFF
--- a/pkg/controllers/clusters/clusterstatus/network_test.go
+++ b/pkg/controllers/clusters/clusterstatus/network_test.go
@@ -101,12 +101,14 @@ func TestFindPodCommandParameter(t *testing.T) {
 
 		podLister, err := buildPodLister(pod)
 		if err != nil {
-			t.Errorf("new pod lister error: %v", err)
+			t.Errorf("test for %s error: %v", test.description, err)
 			continue
 		}
 
-		result := findPodCommandParameter(podLister, labelSelector, parameter)
-		if result != expected {
+		result, err := findPodCommandParameter(podLister, labelSelector, parameter)
+		if err != nil {
+			t.Errorf("test for %s error: %v", test.description, err)
+		} else if result != expected {
 			t.Errorf("test for %s: expected %s, got %s", test.description, expected, result)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

Fix/Optimize

#### What this PR does:

 According to submariner [findClusterIPRange](https://github.com/submariner-io/submariner-operator/blob/devel/pkg/discovery/network/generic.go#L81) function, fix ignored finding pod error, which means something wrong.

Related PR: #833