### PR TITLE
remove cluster_bootstrap_token expiration date

### DIFF
--- a/manifests/samples/cluster_bootstrap_token.yaml
+++ b/manifests/samples/cluster_bootstrap_token.yaml
@@ -16,7 +16,7 @@ stringData:
   token-secret: f395accd246ae52d
 
   # Expiration. Optional.
-  expiration: 2025-05-10T03:22:11Z
+  # expiration: 2025-05-10T03:22:11Z
 
   # Allowed usages.
   usage-bootstrap-authentication: "true"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
fix

#### What this PR does / why we need it:
In the quick start sample, hack/local-running.sh use this yaml to create the cluster_bootstrap_token. However, since the expiration date is 2025-05-10, this token is quickly cleared by kcm, which lead to the unauthorized error in clusternet-agent.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
