### PR TITLE
Fix nil pointer panic when creating CRD resources via ShadowAPI

### DIFF
--- a/pkg/hub/apiserver/shadow/customresource_handler.go
+++ b/pkg/hub/apiserver/shadow/customresource_handler.go
@@ -34,9 +34,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -282,7 +284,11 @@ func (r *crdHandler) addStorage(crd *apiextensionsv1.CustomResourceDefinition) e
 	if !canBeAddedToStorage(crd.Spec.Group, storageVersion, crd.Spec.Names.Plural, r.apiserviceLister) {
 		return nil
 	}
-	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Group: crd.Spec.Group, Version: storageVersion})
+	groupVersion := schema.GroupVersion{Group: crd.Spec.Group, Version: storageVersion}
+	metav1.AddToGroupVersion(Scheme, groupVersion)
+	Scheme.AddKnownTypeWithName(groupVersion.WithKind(crd.Spec.Names.Kind),
+		&unstructured.Unstructured{},
+	)
 
 	r.versionDiscoveryHandler.updateCRD(crd)
 
@@ -324,6 +330,21 @@ func (r *crdHandler) addStorage(crd *apiextensionsv1.CustomResourceDefinition) e
 		}
 	}
 
+	typeConverter := managedfields.NewDeducedTypeConverter()
+	fieldManager, err := managedfields.NewDefaultFieldManager(
+		typeConverter,
+		crdGroupInfo.Scheme,
+		crdGroupInfo.Scheme,
+		crdGroupInfo.Scheme,
+		groupVersionKind,
+		groupVersionKind.GroupVersion(),
+		"",
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create field manager for %s: %v", resource, err)
+	}
+
 	r.lock.Lock()
 	r.storages[resource] = restStorage
 	r.requestScopes[resource] = &handlers.RequestScope{
@@ -345,6 +366,7 @@ func (r *crdHandler) addStorage(crd *apiextensionsv1.CustomResourceDefinition) e
 		HubGroupVersion:          groupVersionKind.GroupVersion(),
 		MetaGroupVersion:         metav1.SchemeGroupVersion,
 		TableConvertor:           restStorage,
+		FieldManager:             fieldManager,
 		Authorizer:               r.authorizer,
 		MaxRequestBodyBytes:      r.maxRequestBodyBytes,
 	}


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What this PR does / why we need it:

When creating Custom Resource objects through the ShadowAPI in push mode (e.g. via `kubectl clusternet apply`), the hub panics with a nil pointer dereference in `FieldManager.UpdateNoErrors()`, returning a `ServiceUnavailable` error.

The root cause is two missing initializations in the CRD handler's `addStorage` method in `pkg/hub/apiserver/shadow/customresource_handler.go`:

1. **Missing `Scheme.AddKnownTypeWithName()`**: The non-CRD path in `apiserver.go` correctly calls both `Scheme.AddKnownTypeWithName()` and `metav1.AddToGroupVersion()` to register resource kinds. The CRD handler only called `metav1.AddToGroupVersion()`, so the Scheme could not recognize the CRD's GroupVersionKind.

2. **Missing `FieldManager` in `RequestScope`**: Since Kubernetes 1.30+, `handlers.CreateResource()` requires `RequestScope.FieldManager` to be non-nil for server-side apply and managed fields tracking. The manually constructed `RequestScope` for CRDs was missing this field, causing the nil pointer panic.

This PR fixes both issues by:
- Adding `Scheme.AddKnownTypeWithName()` to register CRD kinds as `Unstructured` objects, matching the existing non-CRD code path.
- Initializing a `FieldManager` using `managedfields.NewDeducedTypeConverter()` (appropriate for CRDs without a full OpenAPI schema) and including it in the `RequestScope`.

#### Which issue(s) this PR fixes:

Fixes #919

#### Special notes for your reviewer:

The fix mirrors patterns already used in the same package:
- `Scheme.AddKnownTypeWithName()` matches the non-CRD registration in `apiserver.go:221-224`
- `NewDeducedTypeConverter()` is the standard approach for CRDs that don't have a full OpenAPI schema, as used in `k8s.io/apiextensions-apiserver`