### PR TITLE
Fix Helm target namespace fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.32.4
 	k8s.io/apimachinery v0.32.4
 	k8s.io/apiserver v0.32.4
+	k8s.io/cli-runtime v0.32.4
 	k8s.io/client-go v0.32.4
 	k8s.io/cluster-bootstrap v0.32.4
 	k8s.io/code-generator v0.32.4
@@ -188,7 +189,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/cli-runtime v0.32.4 // indirect
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 // indirect
 	k8s.io/kms v0.32.4 // indirect
 	oras.land/oras-go v1.2.5 // indirect

--- a/pkg/utils/deployer.go
+++ b/pkg/utils/deployer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	actionkube "helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -47,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -133,8 +135,7 @@ func ReconcileHelmRelease(ctx context.Context, deployCtx *DeployContext, kubeCli
 		return err
 	}
 
-	cfg := new(action.Configuration)
-	err = cfg.Init(deployCtx, hr.Spec.TargetNamespace, "secret", klog.V(5).Infof)
+	cfg, err := initHelmActionConfiguration(deployCtx, hr.Spec.TargetNamespace, "secret", klog.V(5).Infof)
 	if err != nil {
 		return err
 	}
@@ -272,6 +273,20 @@ func ReconcileHelmRelease(ctx context.Context, deployCtx *DeployContext, kubeCli
 	return err
 }
 
+func initHelmActionConfiguration(
+	getter genericclioptions.RESTClientGetter,
+	namespace, helmDriver string,
+	log action.DebugLog,
+) (*action.Configuration, error) {
+	cfg := new(action.Configuration)
+	if err := cfg.Init(getter, namespace, helmDriver, log); err != nil {
+		return nil, err
+	}
+	if kubeClient, ok := cfg.KubeClient.(*actionkube.Client); ok {
+		kubeClient.Namespace = namespace
+	}
+	return cfg, nil
+}
 func GenerateHelmReleaseName(descName string, chartRef appsapi.ChartReference) string {
 	return fmt.Sprintf("%s-%s-%s", descName, chartRef.Namespace, chartRef.Name)
 }

--- a/pkg/utils/deployer_test.go
+++ b/pkg/utils/deployer_test.go
@@ -19,8 +19,10 @@ package utils
 import (
 	"testing"
 
+	actionkube "helm.sh/helm/v3/pkg/kube"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	clusterapi "github.com/clusternet/clusternet/pkg/apis/clusters/v1beta1"
 )
@@ -316,5 +318,43 @@ func TestClusterHasReadyCondition(t *testing.T) {
 				t.Errorf("ClusterHasReadyCondition() = %v, want %v", isReady, tt.clusterReady)
 			}
 		})
+	}
+}
+func TestInitHelmActionConfigurationSetsKubeClientNamespace(t *testing.T) {
+	config := &clientcmdapi.Config{
+		CurrentContext: "ctx",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster": {
+				Server: "https://127.0.0.1:6443",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"ctx": {
+				Cluster:   "cluster",
+				AuthInfo:  "user",
+				Namespace: "default",
+			},
+		},
+	}
+
+	deployCtx, err := NewDeployContext(config, 5, 10)
+	if err != nil {
+		t.Fatalf("NewDeployContext() error = %v", err)
+	}
+
+	cfg, err := initHelmActionConfiguration(deployCtx, "blueking", "secret", t.Logf)
+	if err != nil {
+		t.Fatalf("initHelmActionConfiguration() error = %v", err)
+	}
+
+	kubeClient, ok := cfg.KubeClient.(*actionkube.Client)
+	if !ok {
+		t.Fatalf("cfg.KubeClient type = %T, want *kube.Client", cfg.KubeClient)
+	}
+	if kubeClient.Namespace != "blueking" {
+		t.Fatalf("cfg.KubeClient.Namespace = %q, want %q", kubeClient.Namespace, "blueking")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

  /kind bug

#### What this PR does / why we need it:

  This PR fixes Helm resource namespace fallback during HelmRelease reconciliation.

  When Clusternet initializes Helm actions, it passes `targetNamespace` into Helm storage, but Helm's kube client can still fall back to the kubeconfig
  context namespace for namespaced resources that do not explicitly set `metadata.namespace`. In practice, this can cause resources from a HelmRelease
  targeting a namespace like `test-ns` to be applied into `default`.

  This change initializes Helm action configuration through a helper that explicitly sets the Helm kube client's default namespace to
  `HelmRelease.spec.targetNamespace`, so resources without an explicit namespace are applied to the intended target namespace. A regression test is added to
  verify that the Helm kube client uses `targetNamespace` instead of the kubeconfig context namespace.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
