### PR TITLE
WIP: Fix late HelmChart localization matching

### DIFF
--- a/pkg/controllermanager/deployer/deployer.go
+++ b/pkg/controllermanager/deployer/deployer.go
@@ -1101,15 +1101,41 @@ func (deployer *Deployer) handleHelmChart(chartCopy *appsapi.HelmChart) error {
 		return err
 	}
 
-	// find all referred Base UIDs
-	var baseUIDs []string
-	for key, val := range chartCopy.Labels {
+	baseUIDs, err := deployer.findBaseUIDsForHelmChart(chartCopy)
+	if err != nil {
+		return err
+	}
+	return deployer.resyncBase(baseUIDs...)
+}
+
+func (deployer *Deployer) findBaseUIDsForHelmChart(chart *appsapi.HelmChart) ([]string, error) {
+	baseUIDs := sets.String{}
+	for key, val := range chart.Labels {
 		if val == baseKind.Kind {
-			baseUIDs = append(baseUIDs, key)
+			baseUIDs.Insert(key)
 		}
 	}
 
-	return deployer.resyncBase(baseUIDs...)
+	bases, err := deployer.baseLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	feed := appsapi.Feed{
+		Kind:       helmChartKind.Kind,
+		APIVersion: helmChartKind.GroupVersion().String(),
+		Namespace:  chart.Namespace,
+		Name:       chart.Name,
+	}
+	for _, base := range bases {
+		if base.DeletionTimestamp != nil || len(base.UID) == 0 {
+			continue
+		}
+		if utils.HasFeed(feed, base.Spec.Feeds) {
+			baseUIDs.Insert(string(base.UID))
+		}
+	}
+
+	return baseUIDs.List(), nil
 }
 
 func (deployer *Deployer) resyncBase(baseUIDs ...string) error {

--- a/pkg/controllermanager/deployer/deployer_test.go
+++ b/pkg/controllermanager/deployer/deployer_test.go
@@ -71,3 +71,45 @@ func TestGetBaseForUpdateFallsBackToLiveGetWhenListerMissesAlreadyExistingBase(t
 		t.Fatalf("getBaseForUpdate() got feed name %q, want %q", base.Spec.Feeds[0].Name, "old")
 	}
 }
+
+func TestFindBaseUIDsForHelmChartFallsBackToBaseFeedsWhenChartLabelMissing(t *testing.T) {
+	chart := &appsapi.HelmChart{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx",
+			Namespace: "charts",
+		},
+	}
+	base := &appsapi.Base{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-base",
+			Namespace: "cluster-a",
+			UID:       types.UID("d4d9da23-cd45-4c61-baf7-c39b45795ed7"),
+		},
+		Spec: appsapi.BaseSpec{
+			Feeds: []appsapi.Feed{
+				{
+					APIVersion: "apps.clusternet.io/v1alpha1",
+					Kind:       "HelmChart",
+					Namespace:  chart.Namespace,
+					Name:       chart.Name,
+				},
+			},
+		},
+	}
+
+	baseIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := baseIndexer.Add(base); err != nil {
+		t.Fatalf("failed to add Base to indexer: %v", err)
+	}
+	deployer := &Deployer{
+		baseLister: applisters.NewBaseLister(baseIndexer),
+	}
+
+	got, err := deployer.findBaseUIDsForHelmChart(chart)
+	if err != nil {
+		t.Fatalf("findBaseUIDsForHelmChart() returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != string(base.UID) {
+		t.Fatalf("findBaseUIDsForHelmChart() = %v, want [%s]", got, base.UID)
+	}
+}

--- a/pkg/controllermanager/deployer/localizer/localizer.go
+++ b/pkg/controllermanager/deployer/localizer/localizer.go
@@ -298,7 +298,7 @@ func (l *Localizer) ApplyOverridesToDescription(desc *appsapi.Description) error
 		for idx, chartRef := range desc.Spec.Charts {
 			overrides, err := l.getOverrides(desc.Namespace, appsapi.Feed{
 				Kind:       chartKind.Kind,
-				APIVersion: chartKind.Version,
+				APIVersion: chartKind.GroupVersion().String(),
 				Namespace:  chartRef.Namespace,
 				Name:       chartRef.Name,
 			})
@@ -394,6 +394,10 @@ func (l *Localizer) getOverrides(namespace string, feed appsapi.Feed) ([]appsapi
 	if err != nil {
 		return nil, err
 	}
+	feedGlobs, err = l.appendGlobalizationsMatchingFeed(feedGlobs, feed)
+	if err != nil {
+		return nil, err
+	}
 
 	globs := make([]*appsapi.Globalization, 0)
 	for _, glob := range feedGlobs {
@@ -433,6 +437,10 @@ func (l *Localizer) getOverrides(namespace string, feed appsapi.Feed) ([]appsapi
 	if err != nil {
 		return nil, err
 	}
+	locs, err = l.appendLocalizationsMatchingFeed(namespace, locs, feed)
+	if err != nil {
+		return nil, err
+	}
 	sort.SliceStable(locs, func(i, j int) bool {
 		if locs[i].Spec.Priority == locs[j].Spec.Priority {
 			return locs[i].CreationTimestamp.Second() < locs[j].CreationTimestamp.Second()
@@ -456,4 +464,49 @@ func (l *Localizer) getOverrides(namespace string, feed appsapi.Feed) ([]appsapi
 	}
 
 	return allOverrideConfigs, nil
+}
+
+func (l *Localizer) appendGlobalizationsMatchingFeed(globs []*appsapi.Globalization, feed appsapi.Feed) ([]*appsapi.Globalization, error) {
+	allGlobs, err := l.globLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(globs))
+	for _, glob := range globs {
+		seen[glob.Name] = struct{}{}
+	}
+	for _, glob := range allGlobs {
+		if _, ok := seen[glob.Name]; ok {
+			continue
+		}
+		if utils.FeedMatches(glob.Spec.Feed, feed) {
+			globs = append(globs, glob)
+			seen[glob.Name] = struct{}{}
+		}
+	}
+	return globs, nil
+}
+
+func (l *Localizer) appendLocalizationsMatchingFeed(namespace string, locs []*appsapi.Localization, feed appsapi.Feed) ([]*appsapi.Localization, error) {
+	allLocs, err := l.locLister.Localizations(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(locs))
+	for _, loc := range locs {
+		seen[klog.KObj(loc).String()] = struct{}{}
+	}
+	for _, loc := range allLocs {
+		key := klog.KObj(loc).String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		if utils.FeedMatches(loc.Spec.Feed, feed) {
+			locs = append(locs, loc)
+			seen[key] = struct{}{}
+		}
+	}
+	return locs, nil
 }

--- a/pkg/controllermanager/deployer/localizer/localizer_test.go
+++ b/pkg/controllermanager/deployer/localizer/localizer_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Clusternet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localizer
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+
+	appsapi "github.com/clusternet/clusternet/pkg/apis/apps/v1alpha1"
+	applisters "github.com/clusternet/clusternet/pkg/generated/listers/apps/v1alpha1"
+	clusterlisters "github.com/clusternet/clusternet/pkg/generated/listers/clusters/v1beta1"
+)
+
+func TestApplyOverridesToDescriptionFallsBackToFeedWhenLocalizationUIDLabelMissing(t *testing.T) {
+	chart := &appsapi.HelmChart{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx",
+			Namespace: "charts",
+			UID:       types.UID("0230fe0b-c23a-49fe-b02b-829d76b98a25"),
+		},
+	}
+	loc := &appsapi.Localization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-values",
+			Namespace: "cluster-a",
+		},
+		Spec: appsapi.LocalizationSpec{
+			Feed: appsapi.Feed{
+				Kind:       chartKind.Kind,
+				APIVersion: chartKind.GroupVersion().String(),
+				Namespace:  chart.Namespace,
+				Name:       chart.Name,
+			},
+			Overrides: []appsapi.OverrideConfig{
+				{
+					Name:  "set replica count",
+					Type:  appsapi.HelmType,
+					Value: `{"replicaCount":3}`,
+				},
+			},
+		},
+	}
+
+	chartIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := chartIndexer.Add(chart); err != nil {
+		t.Fatalf("failed to add HelmChart to indexer: %v", err)
+	}
+	locIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	if err := locIndexer.Add(loc); err != nil {
+		t.Fatalf("failed to add Localization to indexer: %v", err)
+	}
+
+	l := &Localizer{
+		chartLister: applisters.NewHelmChartLister(chartIndexer),
+		locLister:   applisters.NewLocalizationLister(locIndexer),
+		globLister:  applisters.NewGlobalizationLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+		mclsLister:  clusterlisters.NewManagedClusterLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})),
+	}
+
+	desc := &appsapi.Description{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "cluster-a",
+		},
+		Spec: appsapi.DescriptionSpec{
+			Deployer: appsapi.DescriptionHelmDeployer,
+			Charts: []appsapi.ChartReference{
+				{
+					Namespace: chart.Namespace,
+					Name:      chart.Name,
+				},
+			},
+			ChartRaw: [][]byte{[]byte(`{"kind":"HelmChart","metadata":{"name":"nginx","namespace":"charts"}}`)},
+		},
+	}
+
+	if err := l.ApplyOverridesToDescription(desc); err != nil {
+		t.Fatalf("ApplyOverridesToDescription() returned error: %v", err)
+	}
+	if got, want := string(desc.Spec.Raw[0]), `{"replicaCount":3}`; got != want {
+		t.Fatalf("ApplyOverridesToDescription() raw override = %q, want %q", got, want)
+	}
+}

--- a/pkg/controllers/apps/globalization/globalization.go
+++ b/pkg/controllers/apps/globalization/globalization.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -107,6 +108,7 @@ func NewController(
 			// ADD/DELETE/OTHER UPDATE
 			return true, nil
 		})
+	c.yachtController = yachtController
 
 	// Manage the addition/update of Globalization
 	_, err := globInformer.Informer().AddEventHandler(yachtController.DefaultResourceEventHandlerFuncs())
@@ -114,7 +116,29 @@ func NewController(
 		return nil, err
 	}
 
-	c.yachtController = yachtController
+	_, err = chartInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			chart := obj.(*appsapi.HelmChart)
+			c.enqueueGlobalizationsForHelmChart(chart)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldChart := oldObj.(*appsapi.HelmChart)
+			newChart := newObj.(*appsapi.HelmChart)
+			if newChart.DeletionTimestamp != nil {
+				return
+			}
+			if oldChart.UID == newChart.UID &&
+				reflect.DeepEqual(oldChart.Spec, newChart.Spec) &&
+				reflect.DeepEqual(oldChart.Labels, newChart.Labels) {
+				return
+			}
+			c.enqueueGlobalizationsForHelmChart(newChart)
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }
 
@@ -229,6 +253,34 @@ func (c *Controller) getLabelsForPatching(glob *appsapi.Globalization) (map[stri
 
 	}
 	return labelsToPatch, nil
+}
+
+func (c *Controller) enqueueGlobalizationsForHelmChart(chart *appsapi.HelmChart) {
+	if chart.DeletionTimestamp != nil {
+		return
+	}
+
+	globs, err := c.globLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list Globalizations for HelmChart %s: %v", klog.KObj(chart), err))
+		return
+	}
+
+	feed := appsapi.Feed{
+		Kind:       chartKind.Kind,
+		APIVersion: chartKind.GroupVersion().String(),
+		Namespace:  chart.Namespace,
+		Name:       chart.Name,
+	}
+	for _, glob := range globs {
+		if glob.DeletionTimestamp != nil {
+			continue
+		}
+		if utils.FeedMatches(glob.Spec.Feed, feed) {
+			klog.V(5).Infof("enqueue Globalization %s for HelmChart %s", klog.KObj(glob), klog.KObj(chart))
+			c.yachtController.Enqueue(glob)
+		}
+	}
 }
 
 func (c *Controller) patchGlobalizationLabels(glob *appsapi.Globalization, labels map[string]*string) (*appsapi.Globalization, error) {

--- a/pkg/controllers/apps/localization/localization.go
+++ b/pkg/controllers/apps/localization/localization.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -109,6 +110,7 @@ func NewController(
 			// ADD/DELETE/OTHER UPDATE
 			return true, nil
 		})
+	c.yachtController = yachtController
 
 	// Manage the addition/update of Localization
 	_, err := locInformer.Informer().AddEventHandler(yachtController.DefaultResourceEventHandlerFuncs())
@@ -116,7 +118,29 @@ func NewController(
 		return nil, err
 	}
 
-	c.yachtController = yachtController
+	_, err = chartInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			chart := obj.(*appsapi.HelmChart)
+			c.enqueueLocalizationsForHelmChart(chart)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldChart := oldObj.(*appsapi.HelmChart)
+			newChart := newObj.(*appsapi.HelmChart)
+			if newChart.DeletionTimestamp != nil {
+				return
+			}
+			if oldChart.UID == newChart.UID &&
+				reflect.DeepEqual(oldChart.Spec, newChart.Spec) &&
+				reflect.DeepEqual(oldChart.Labels, newChart.Labels) {
+				return
+			}
+			c.enqueueLocalizationsForHelmChart(newChart)
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
 }
 
@@ -227,6 +251,34 @@ func (c *Controller) getLabelsForPatching(loc *appsapi.Localization) (map[string
 	}
 
 	return labelsToPatch, nil
+}
+
+func (c *Controller) enqueueLocalizationsForHelmChart(chart *appsapi.HelmChart) {
+	if chart.DeletionTimestamp != nil {
+		return
+	}
+
+	locs, err := c.locLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list Localizations for HelmChart %s: %v", klog.KObj(chart), err))
+		return
+	}
+
+	feed := appsapi.Feed{
+		Kind:       chartKind.Kind,
+		APIVersion: chartKind.GroupVersion().String(),
+		Namespace:  chart.Namespace,
+		Name:       chart.Name,
+	}
+	for _, loc := range locs {
+		if loc.DeletionTimestamp != nil {
+			continue
+		}
+		if utils.FeedMatches(loc.Spec.Feed, feed) {
+			klog.V(5).Infof("enqueue Localization %s for HelmChart %s", klog.KObj(loc), klog.KObj(chart))
+			c.yachtController.Enqueue(loc)
+		}
+	}
 }
 
 func (c *Controller) patchLocalizationLabels(loc *appsapi.Localization, labels map[string]*string) (*appsapi.Localization, error) {

--- a/pkg/utils/feed.go
+++ b/pkg/utils/feed.go
@@ -86,6 +86,28 @@ func FormatFeed(feed appsapi.Feed) string {
 	return fmt.Sprintf("%s %s", feed.Kind, namespacedName)
 }
 
+func FeedMatches(feed, target appsapi.Feed) bool {
+	if feed.Kind != target.Kind || feed.Namespace != target.Namespace || feed.Name != target.Name {
+		return false
+	}
+	if len(feed.APIVersion) == 0 || len(target.APIVersion) == 0 || feed.APIVersion == target.APIVersion {
+		return true
+	}
+
+	feedGV, err := schema.ParseGroupVersion(feed.APIVersion)
+	if err != nil {
+		return false
+	}
+	targetGV, err := schema.ParseGroupVersion(target.APIVersion)
+	if err != nil {
+		return false
+	}
+	if feedGV.Version != targetGV.Version {
+		return false
+	}
+	return feedGV.Group == targetGV.Group
+}
+
 func RemoveFeedFromSubscription(ctx context.Context, clusternetClient *clusternetclientset.Clientset,
 	feedSourceLabels map[string]string, sub *appsapi.Subscription) error {
 	// we use JSONPatch for simplicity and efficiency
@@ -152,7 +174,7 @@ func FindBasesFromUIDs(baseIndexer cache.Indexer, uids []string) []*appsapi.Base
 
 func HasFeed(feed appsapi.Feed, feeds []appsapi.Feed) bool {
 	for _, f := range feeds {
-		if f.Kind == feed.Kind && f.Namespace == feed.Namespace && f.Name == feed.Name {
+		if FeedMatches(f, feed) {
 			return true
 		}
 	}

--- a/pkg/utils/feed_test.go
+++ b/pkg/utils/feed_test.go
@@ -59,6 +59,100 @@ func TestFormatFeed(t *testing.T) {
 	}
 }
 
+func TestFeedMatches(t *testing.T) {
+	tests := []struct {
+		name   string
+		feed   appsapi.Feed
+		target appsapi.Feed
+		want   bool
+	}{
+		{
+			name: "same feed with full api version",
+			feed: appsapi.Feed{
+				Kind:       "HelmChart",
+				APIVersion: "apps.clusternet.io/v1alpha1",
+				Namespace:  "charts",
+				Name:       "nginx",
+			},
+			target: appsapi.Feed{
+				Kind:       "HelmChart",
+				APIVersion: "apps.clusternet.io/v1alpha1",
+				Namespace:  "charts",
+				Name:       "nginx",
+			},
+			want: true,
+		},
+		{
+			name: "version-only target does not match full api version",
+			feed: appsapi.Feed{
+				Kind:       "HelmChart",
+				APIVersion: "apps.clusternet.io/v1alpha1",
+				Namespace:  "charts",
+				Name:       "nginx",
+			},
+			target: appsapi.Feed{
+				Kind:       "HelmChart",
+				APIVersion: "v1alpha1",
+				Namespace:  "charts",
+				Name:       "nginx",
+			},
+			want: false,
+		},
+		{
+			name: "empty api version matches full api version",
+			feed: appsapi.Feed{
+				Kind:      "HelmChart",
+				Namespace: "charts",
+				Name:      "nginx",
+			},
+			target: appsapi.Feed{
+				Kind:       "HelmChart",
+				APIVersion: "apps.clusternet.io/v1alpha1",
+				Namespace:  "charts",
+				Name:       "nginx",
+			},
+			want: true,
+		},
+		{
+			name: "core v1 does not match custom v1",
+			feed: appsapi.Feed{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+				Namespace:  "default",
+				Name:       "demo",
+			},
+			target: appsapi.Feed{
+				Kind:       "ConfigMap",
+				APIVersion: "example.com/v1",
+				Namespace:  "default",
+				Name:       "demo",
+			},
+			want: false,
+		},
+		{
+			name: "different namespace does not match",
+			feed: appsapi.Feed{
+				Kind:      "HelmChart",
+				Namespace: "charts",
+				Name:      "nginx",
+			},
+			target: appsapi.Feed{
+				Kind:      "HelmChart",
+				Namespace: "default",
+				Name:      "nginx",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FeedMatches(tt.feed, tt.target); got != tt.want {
+				t.Errorf("FeedMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindObsoletedFeeds(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
  Fix late `HelmChart` creation not applying existing `Localization` / `Globalization` overrides.
  `Localization`. After the `HelmChart` is created later, the old `Localization` is not automatically reprocessed, so `getOverrides()` cannot find it by UID
  label. As a result, `Description.spec.raw` and then `HelmRelease.spec.overrides` stay empty.
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

  ## Changes

  - Re-enqueue matching `Localization` objects when a referenced `HelmChart` is added or materially updated, so the UID label can be patched later.
  - Apply the same late-match behavior for `Globalization`.
  - Add a `spec.feed` fallback in localizer override lookup so overrides can still be applied before the UID label is patched.
  - Re-sync related `Base` objects by checking `Base.spec.feeds`, not only existing labels on the `HelmChart`.
  - Tighten feed matching to avoid treating core `v1` as an API group wildcard.
  - Add regression tests for late `HelmChart` matching and feed matching behavior.